### PR TITLE
Ensure unittests run with an isolated home directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,8 @@ def hypervisor_collector(backendid, config_manager):
     return hypervisor_coll
 
 @pytest.fixture
-def scc_hypervisor_collector_cli():
+def scc_hypervisor_collector_cli(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
     return cli
 
 def pytest_configure(config):


### PR DESCRIPTION
Running the unittests should not suffer side effects if the user has
valid configuration files in the standard location under their home
directory.

To avoid this for the CLI unittests we override the HOME env var to
point at an temporary directory.

Closes: #13