### PR TITLE
Enable pytest coverage failures being propagated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,14 +35,13 @@ usedevelop =
 deps =
     -r requirements.txt
     pytest
-    pytest[psutils]
+    pytest-xdist
+    pytest-xdist[psutils]
     cover: pytest-cov
     testfixtures
     mock
 commands =
-    # TODO(fergal): Enable failure reporting once test coverage
-    # is sufficient.
-    {posargs:-pytest -vv \
+    {posargs:pytest -vv \
     cover:                 --no-cov-on-fail \
     cover:                 --cov=src \
     cover:                 --cov-report=term-missing \


### PR DESCRIPTION
Now that we have sufficient coverage in our unittesting we can start
propagating the test failures.

Also corectly include pytest-xdist to enable potential parallelised
testing in pytest runs.