### PR TITLE
virtual-host-gatherer integration cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ libvirt-python
 pycurl
 pyvmomi
 six
-virtual-host-gatherer @ git+https://github.com/uyuni-project/virtual-host-gatherer.git#egg=virtual-host-gatherer@virtual-host-gatherer-1.0.23-1&subdirectory=virtual-host-gatherer
+virtual-host-gatherer @ git+https://github.com/uyuni-project/virtual-host-gatherer.git#egg=virtual-host-gatherer@main&subdirectory=virtual-host-gatherer

--- a/src/scc_hypervisor_collector/api/gatherer.py
+++ b/src/scc_hypervisor_collector/api/gatherer.py
@@ -5,7 +5,6 @@ The VHGather is a wrapper class for managing virtual-host-gatherer
 integration.
 """
 
-from argparse import Namespace
 import logging
 from typing import (Any, cast, Dict, Optional, Sequence)
 
@@ -19,19 +18,7 @@ class VHGatherer:
 
     def __init__(self) -> None:
 
-        # Workaround for limitations in virtual-host-gather v1.0.23
-        # save current logging level
-        loglevel = LOG.level
-
-        self._gatherer: Gatherer = Gatherer(
-            # Workaround for limitations in virtual-host-gather v1.0.23
-            opts=Namespace(logfile='/tmp/test.log')
-        )
-
-        # Workaround for limitations in virtual-host-gather v1.0.23
-        # restore current logging level
-        LOG.setLevel(loglevel)
-
+        self._gatherer: Gatherer = Gatherer()
         self._module_params: Optional[Dict[str, Dict]] = None
 
     @property


### PR DESCRIPTION
Remove the hackery added to the VHGatherer.__init__() method that
were required to workaround issues integrating with older versions
of virtual-host-gatherer.

Temporarily point at modified fork containing candidate changes to
the virtual-host-gatherer.

Closes: #9