### PR TITLE
support check mode to report all possible config errors

### DIFF
--- a/src/scc_hypervisor_collector/api/config_manager.py
+++ b/src/scc_hypervisor_collector/api/config_manager.py
@@ -45,7 +45,8 @@ class ConfigManager:
     """
 
     def __init__(self, config_file: Optional[str] = None,
-                 config_dir: Optional[str] = None):
+                 config_dir: Optional[str] = None,
+                 check: bool = False):
         """Initialiser for ConfigManager"""
 
         LOG.debug("config_file: %s, config_dir: %s", repr(config_file),
@@ -63,6 +64,8 @@ class ConfigManager:
             # use expanduser() to expand ~'s
             Path(config_dir).expanduser() if config_dir else None
         )
+
+        self._check = check
 
         # Lazy loaded configuration data
         self._config_data: Optional[CollectorConfig] = None
@@ -226,5 +229,6 @@ class ConfigManager:
         """Return the config_data loaded from the specifed config
            sources."""
         if self._config_data is None:
-            self._config_data = CollectorConfig(self._load_config())
+            self._config_data = CollectorConfig(self._load_config(),
+                                                _check=self._check)
         return self._config_data

--- a/src/scc_hypervisor_collector/cli/__init__.py
+++ b/src/scc_hypervisor_collector/cli/__init__.py
@@ -52,11 +52,14 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     logging.basicConfig(level=log_level)
 
     cfg_mgr = ConfigManager(config_file=args.config,
-                            config_dir=args.config_dir)
+                            config_dir=args.config_dir,
+                            check=args.check)
 
     logging.info("ConfigManager: config_data = %s", repr(cfg_mgr.config_data))
 
     if args.check:
+        for error in cfg_mgr.config_data.config_errors:
+            print(error)
         sys.exit(0)
 
     scheduler = CollectionScheduler(cfg_mgr.config_data)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -148,11 +148,8 @@ class TestConfigManager:
 
     @pytest.mark.config('tests/unit/data/config/negative/idlessbackend.yaml', None)
     def test_id_generation(self, config_manager):
-        config_data = config_manager.config_data
-        backends = config_data.get('backends')
-        for backend in backends:
-            #assert random uuid generated
-            assert backend['id']
+        with pytest.raises(exceptions.BackendConfigError):
+            config_manager.config_data
 
     @pytest.mark.config('tests/unit/data/config/default/default.yaml', None)
     def test_missing_fields(self, config_manager):

--- a/tests/unit/test_scc_hypervisor_collector_cli.py
+++ b/tests/unit/test_scc_hypervisor_collector_cli.py
@@ -41,9 +41,7 @@ class TestSCCHypervisorCollectorCLI:
 
     def test_check_option_failure(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--check", "--config-dir", "tests/unit/data/config/invalid"])
-        # TODO: switch to checking for SystemExit with non-zero exit status
-        #       once ConfigManager() check mode is implemented.
-        with pytest.raises(exceptions.CollectorConfigContentError):
+        with pytest.raises(SystemExit):
             scc_hypervisor_collector_cli.main()
         #need to add asssertions when logger is accessible
 


### PR DESCRIPTION
The check mode is used to process and report all the issues
found with the configuration instead of failing on the first
config issue. We maintain the list of config errors in
self._config_errors and append to the list as we encounter
configuration error while processing the configuration.
valid is now recursive as we check validity of the child
config instances.

Fixes #5