### PR TITLE
update handling of the parsed backends key

### DIFF
--- a/src/scc_hypervisor_collector/api/config_manager.py
+++ b/src/scc_hypervisor_collector/api/config_manager.py
@@ -124,6 +124,16 @@ class ConfigManager:
                       'backend with id %s', repr(existing_id))
             backends.remove(no_id_backend)
 
+    @staticmethod
+    def _get_backends(cfg: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """ Return the list of backends - an empty list if
+        backends section is empty
+        """
+        backends: List[Dict[str, Any]] = cfg.get('backends', [])
+        if backends is None:
+            backends = []
+        return backends.copy()
+
     def _merge_config_data(self, old_cfg: Dict[str, Any],
                            new_cfg: Dict[str, Any]) -> None:
         """Merge the new_cfg into the old_cfg.
@@ -135,8 +145,8 @@ class ConfigManager:
         backends_in_new: bool = 'backends' in new_cfg
 
         # Make lightweight copies of backends lists in old and new cfgs
-        old_backends: List[Dict[str, Any]] = old_cfg.get('backends', []).copy()
-        new_backends: List[Dict[str, Any]] = new_cfg.get('backends', []).copy()
+        old_backends: List[Dict[str, Any]] = self._get_backends(old_cfg)
+        new_backends: List[Dict[str, Any]] = self._get_backends(new_cfg)
 
         # Merge new config settings over existing config settings
         old_cfg.update(new_cfg)

--- a/src/scc_hypervisor_collector/api/configuration.py
+++ b/src/scc_hypervisor_collector/api/configuration.py
@@ -539,7 +539,7 @@ class CollectorConfig(GeneralConfig):
             self._config_errors.append(msg)
             if not self._check:
                 raise error
-
+        self.check_for_backends(combined_args)
         try:
             for i, b in enumerate(combined_args["backends"]):
                 try:
@@ -592,3 +592,12 @@ class CollectorConfig(GeneralConfig):
         """
         # return a lightweight copy of the credentials config
         return CredentialsConfig(self['credentials'])
+
+    def check_for_backends(self, combined_args: Dict) -> None:
+        """ check if the configuration has the backends entry"""
+        if not combined_args.get("backends"):
+            msg = "No backends specified in config!"
+            LOG.error(msg)
+            self._config_errors.append(msg)
+            if not self._check:
+                raise BackendConfigError(msg)

--- a/tests/unit/data/config/negative/emptybackends.yaml
+++ b/tests/unit/data/config/negative/emptybackends.yaml
@@ -1,0 +1,6 @@
+---
+backends:
+credentials:
+  scc:
+    username: "asdf"
+    password: "asdf"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -146,6 +146,11 @@ class TestConfigManager:
         with pytest.raises(AttributeError):
             scc_config.sensitive_fields = new_set_sensitive_fields
 
+    @pytest.mark.config('tests/unit/data/config/negative/emptybackends.yaml', None)
+    def test_empty_backends_section(self, config_manager):
+        with pytest.raises(exceptions.BackendConfigError):
+            config_manager.config_data
+
     @pytest.mark.config('tests/unit/data/config/negative/idlessbackend.yaml', None)
     def test_id_generation(self, config_manager):
         with pytest.raises(exceptions.BackendConfigError):

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -12,13 +12,6 @@ class TestScheduler:
         with pytest.raises(exceptions.SchedulerInvalidConfigError):
             CollectionScheduler(config=None)
 
-    def test_empty_backends(self):
-        with pytest.raises(exceptions.SchedulerInvalidConfigError):
-            scc_config = SccCredsConfig(username='xyz', password='test')
-            cred_config = CredentialsConfig(scc=scc_config)
-            collector_config = CollectorConfig(credentials=cred_config, backends=[])
-            CollectionScheduler(config=collector_config)
-
     @pytest.mark.config('tests/unit/data/config/mock/config.yaml', None)
     def test_scheduler(self, config_manager):
         backends = config_manager.config_data.backends


### PR DESCRIPTION
when you load a yaml file with an empty backends:
section, you get None assigned to the dict key
backends which was causing the copy() in the
_merge_config_data method to fail with
"AttributeError: 'NoneType' object has no attribute 'copy'".
This change fixes the issue by assigning an empty list
if the backends section is None.

Fixes #19