### PR TITLE
Fix lingering .dev_venv references

### DIFF
--- a/bin/command-wrapper
+++ b/bin/command-wrapper
@@ -3,7 +3,7 @@
 cmd_name="$(basename "${BASH_SOURCE[0]}")"
 cmd_dir="$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")"
 base_dir="$(dirname "${cmd_dir}")"
-venv_bin="${base_dir}/.dev_venv/bin"
+venv_bin="${base_dir}/.venv/bin"
 
 if [[ -d "${venv_bin}" ]]; then
     PATH="${venv_bin}:${PATH}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ tag = True
 
 [tool:pytest]
 norecursedirs =
-    .dev_venv
+    .venv
     .eggs
     .git
     .tox
@@ -19,7 +19,7 @@ norecursedirs =
 testpaths = tests
 
 [flake8]
-exclude = .dev_venv,bin,.tox,.eggs,.git
+exclude = .venv,bin,.tox,.eggs,.git
 
 [coverage:report]
 fail_under = 90


### PR DESCRIPTION
We renamed .dev_venv to .venv but missed a few references.

Spotted when prepping to do a version bump.