### PR TITLE
Add helper scripts for the tox dev venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SCC Hypervisor Collector
 
+![CI](https://github.com/SUSE/scc-hypervisor-collector/actions/workflows/ci-workflow.yml/badge.svg)
+
 The `scc-hypervisor-collector` is a tool that can be used to retrieve basic
 details (UUID, vCPU topology, RAM) from configured hypervisor backends, and
 upload them to the SUSE Customer Center using the configured credentials.
@@ -21,14 +23,23 @@ This project uses the following tools as part of the development process:
 In the [bin directory](bin/) a number of helper scripts are provided:
 * `create-venv` - creates a venv containing the tools (listed above)
   required to support development.
-* `command-wrapper` - a generic command wrapper to can be symlinked to
-  a command name, and when invoked via that symlink will look for the
-  named command in the venv, or failing that will try and run it from
-  the host environment.
+* `command-wrapper` - a generic command wrapper that can be symlinked
+  to a command name, and when invoked via that symlink will look for
+  the named command in the venv, or failing that will try and run it
+  from the host environment.
 * `tox` - a `command-wrapper` symlink that can be used to run `tox`.
-* `bumpversion` and `bump2version` - `command-wrapper` symlinks that can
-   be used to run `bumpversion` and `bump2version`.
+* `bumpversion` and `bump2version` - `command-wrapper` symlinks that
+   can be used to run the `bumpversion` and `bump2version` commands.
 * `black` - a `command-wrapper` symlink that can be used to run `black`.
+* `tox_dev-wrapper` - a generic command wrapper that can be symlinked
+  to a command name, and when invoked via that symlink will look for
+  the named command in the `tox` created `.tox/dev` venv, or failing
+  that will try and run it from the host environment. If you haven't
+  yet created the `.tox/dev` venv it will exit with a message telling
+  you to run `bin/tox -e dev` to create the venv.
+* `scc-hypervisor-collector` and `virtual-host-gatherer` - `tox_dev-wrapper`
+  symlinks that can be used to run the `scc-hypervisor-collector` and
+  `virtual-host-gatherer` commands.
 
 ## Testing
 The [tox.ini] file is configured to run the following tests:
@@ -36,8 +47,17 @@ The [tox.ini] file is configured to run the following tests:
   the command can be run from an installed environment.
 * `check` - this test checks the code for compliance with recommended Python
   coding practices using `flake8`, `pylint` and `mypy` (for data typing).
-* `py<version>-{cover,nocov}` - run `pytest` with/without coverage checking
-  for various potential Python versions; missing versions will be skipped.
+* `py<version>-cover` - run `pytest` with/without coverage checking for
+  various potential Python versions; missing Python versions will be
+  skipped.
+
+Additional tests are also available to be run:
+* `py<version>-nocov` - run `pytest` without coverage checking against
+  installed versions of the code for various potential Python versions;
+  missing Python versions will be skipped.
+* `dev` - installs the package's dependencies and then installs the package
+  itself in developer mode, allowing you to run the code locally for adhoc
+  testing purposes via `bin/scc-hypervisor-collector`.
 
 ### Enabling multiple Python version testing with pyenv
 If you have [pyenv](https://github.com/pyenv/pyenv) installed you can enable
@@ -55,7 +75,7 @@ the Python interpreter using `pyenv install <version>` for them to actually be
 available for use by `tox`.
 
 # The scc-hypervisor-collector design
-The tool is broken down into a number of component APIs which are implemted as
+The tool is broken down into a number of component APIs which are implemented as
 subpackages within the main `scc-hypervisor-collector` package.
 
 ## `ConfigManager` - Configuration Management
@@ -75,5 +95,3 @@ TBD
 
 ## Configuration Schema
 TBD
-
-[CI](https://github.com/SUSE/scc-hypervisor-collector/actions/workflows/ci-workflow.yml/badge.svg)

--- a/bin/scc-hypervisor-collector
+++ b/bin/scc-hypervisor-collector
@@ -1,0 +1,1 @@
+tox_dev-wrapper

--- a/bin/tox_dev-wrapper
+++ b/bin/tox_dev-wrapper
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+
+cmd_name="$(basename "${BASH_SOURCE[0]}")"
+cmd_dir="$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")"
+base_dir="$(dirname "${cmd_dir}")"
+dev_bin="${base_dir}/.tox/dev/bin"
+
+if [[ -d "${dev_bin}" ]]; then
+    PATH="${dev_bin}:${PATH}"
+else
+    echo "Please run 'bin/tox -e dev' to create the .tox/dev venv first."
+    exit 1
+fi
+
+exec "${cmd_name}" "${@}"
+
+# vim:shiftwidth=4:tabstop=4:expandtab

--- a/bin/virtual-host-gatherer
+++ b/bin/virtual-host-gatherer
@@ -1,0 +1,1 @@
+tox_dev-wrapper


### PR DESCRIPTION
Our tox.ini defines a dev test that sets up a venv with all of the
required dependencies installed as well as installing our tool in
developer mode.

Add some helper scripts to the bin directory to leverage this to
better enable local adhoc testing of the tool.

Update the README.md to reflect these changes and add some details
about the tox dev venv. Also update the tox testing overview to
align with with recent changes to the tox.ini. Move the CI status
image to the top of the README.md, and add a leading exclamation
mark to indicate that we want to show the referenced image.