### PR TITLE
Validate file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ available for use by `tox`.
 The tool is broken down into a number of component APIs which are implemted as
 subpackages within the main `scc-hypervisor-collector` package.
 
+## `Inputs` - Configuration directory and files
+The config directory and files provided as arguments for the tool has 
+sensitive information that needs to be protected. The tool requires 
+these to be owned by the user running the tool. The permissions on these 
+config files need to be read/write (0600) and the config directory should 
+be user access only (0700) for the user that will run the tool. 
+The tool cannot be run with root privileges. 
+
 ## `ConfigManager` - Configuration Management
 TBD
 

--- a/src/scc_hypervisor_collector/cli/__init__.py
+++ b/src/scc_hypervisor_collector/cli/__init__.py
@@ -3,6 +3,7 @@ SCC Hypervisor Collect CLI Implementation
 """
 import argparse
 import logging
+import os
 import sys
 from typing import (Optional, Sequence)
 import yaml
@@ -50,6 +51,10 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         log_level = logging.INFO
 
     logging.basicConfig(level=log_level)
+
+    # Check for privileges - cannot be run as root
+    if os.geteuid() == 0:
+        sys.exit('This tool cannot be run as root!')
 
     cfg_mgr = ConfigManager(config_file=args.config,
                             config_dir=args.config_dir,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,20 @@
 import pytest
-import json
-import mock
+import os
 
-from scc_hypervisor_collector.api import ConfigManager, CollectionScheduler, HypervisorCollector
+from scc_hypervisor_collector.api import ConfigManager, HypervisorCollector
 from scc_hypervisor_collector import cli
 
+
+@pytest.fixture(scope="session", autouse=True)
+def data_config_permissions(pytestconfig):
+    config = pytestconfig
+    # Update file permissions of the tests/unit/data folder
+    location = config.rootpath / "tests/unit/data"
+    for root, dirs, files in os.walk(location):
+        for dir in [os.path.join(root, d) for d in dirs]:
+            os.chmod(dir, 0o700)
+        for file in [os.path.join(root, f) for f in files]:
+            os.chmod(file, 0o600)
 
 @pytest.fixture
 def config_manager(request):
@@ -32,5 +42,3 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", ('config: the configuration passed on to config manager')
     )
-
-


### PR DESCRIPTION
As part of the security consideration,
we are enforcing that the config files
and directory which hosts sensitive
information that this tool reads
 have limited permissions.

Fixes #6