### PR TITLE
Ensure examples config permissions are correct for spec check

### DIFF
--- a/scc-hypervisor-collector.spec
+++ b/scc-hypervisor-collector.spec
@@ -72,6 +72,8 @@ install -m 0644 doc/%{name}.1 %{buildroot}%{_mandir}/man1/
 
 %check
 export PYTHONPATH=%{buildroot}%{python_sitelib}
+# ensure example config permissions are correct
+chmod -R g-rwx,o-rwx examples
 %{buildroot}%{_bindir}/%{name} -h
 %{buildroot}%{_bindir}/%{name} --check --config examples/shc_cfg.yaml
 


### PR DESCRIPTION
The recent changes to address #6 require that config files and config
directories have appropriate restricted permissions, so update the
check section in the spec file to remove group and other permissions.