### PR TITLE
check-manifest needs to ignore spec file.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,15 @@ version = attr: scc_hypervisor_collector.__version__
 
 [bumpversion:file:src/scc_hypervisor_collector/__init__.py]
 
+[check-manifest]
+ignore =
+	tox.ini
+	*.spec
+	*requirements.txt
+	bin/**
+	tests/**
+	examples/**
+
 [tool:pytest]
 norecursedirs = 
 	.venv

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ deps =
     pylint
 skip_install = true
 commands =
-    check-manifest --ignore 'tox.ini,*requirements.txt,bin/**,tests/**,examples/**'
+    check-manifest
     python setup.py check -m -s
     flake8 src
     mypy --disallow-untyped-defs \


### PR DESCRIPTION
Add the OBS spec file to list of files that should be ignored by the
check-manifest tool as part of the tox 'check' test.

Also move check-manifest ignore option specification to be managed by
setup.cfg rather than as a option on the check-manifest command line
in the tox commands list.

Relates: #11