### PR TITLE
Ensure CI testing runs all checks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 
 [gh-actions]
 python =
-    3.6: py36
+    3.6: py36, check, cli
     3.7: py37
     3.8: py38
     3.9: py39
@@ -80,9 +80,12 @@ commands =
 description = Run scc-hypervisor-collector test commands
 deps =
     -r requirements.txt
+whitelist_externals =
+    chmod
 commands =
     scc-hypervisor-collector --help
     scc-hypervisor-collector --version
+    chmod -R g-rwx,o-rwx {toxinidir}/examples  # ensure correct permission
     scc-hypervisor-collector --check --config {toxinidir}/examples/shc_cfg.yaml
 
 [testenv:dev]


### PR DESCRIPTION
Update the gh-actions config settings in tox.ini to include the check and cli tests in the Python 3.6 tests list.

Address cli test failure by ensuring that the examples directory has the appropriate permissions.

Fixes: #27