### PR TITLE
Run tests during package build

### DIFF
--- a/scc-hypervisor-collector.spec
+++ b/scc-hypervisor-collector.spec
@@ -36,6 +36,8 @@ BuildRequires:  %{python_module PyYAML}
 BuildRequires:  %{python_module devel}
 BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
+BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module mock}
 BuildRequires:  virtual-host-gatherer-Libvirt
 BuildRequires:  virtual-host-gatherer-VMware
 Requires:       %{python_module PyYAML}
@@ -72,12 +74,14 @@ install -m 0644 doc/%{name}.1 %{buildroot}%{_mandir}/man1/
 
 %check
 export PYTHONPATH=%{buildroot}%{python_sitelib}
+
 # ensure example config permissions are correct
 chmod -R g-rwx,o-rwx examples
 %{buildroot}%{_bindir}/%{name} -h
 %{buildroot}%{_bindir}/%{name} --check --config examples/shc_cfg.yaml
 
-#TODO: run pytests
+# run tests
+pytest -vv
 
 %files
 %{_bindir}/%{name}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import pathlib
 import pytest
 import os
 
@@ -8,8 +9,14 @@ from scc_hypervisor_collector import cli
 @pytest.fixture(scope="session", autouse=True)
 def data_config_permissions(pytestconfig):
     config = pytestconfig
+    # Get repo root directory, supporting older versions of pytest
+    # that don't have rootpath
+    if hasattr(config, 'rootpath'):
+        reporoot = config.rootpath
+    else:
+        reporoot = pathlib.Path(config.rootdir)
+    location = reporoot / "tests/unit/data"
     # Update file permissions of the tests/unit/data folder
-    location = config.rootpath / "tests/unit/data"
     for root, dirs, files in os.walk(location):
         for dir in [os.path.join(root, d) for d in dirs]:
             os.chmod(dir, 0o700)


### PR DESCRIPTION
To enable running the pytest tests during package build, we need to
install the pytest and mock packages.

Additionally the older version of pytest that is available for SLE 15
SP2/3/4 doesn't expose a rootpath attribute from pytestconfig, so add
some code to conditionally work around that.

Relates: #11