### PR TITLE
Restructure logging

### DIFF
--- a/src/scc_hypervisor_collector/api/__init__.py
+++ b/src/scc_hypervisor_collector/api/__init__.py
@@ -7,16 +7,19 @@ This package implements the API for the SCC Hypervisor Collector.
 from .exceptions import (
     BackendConfigError,
     ConfigManagerError,
+    ConfigManagerException,
     ConflictingBackendsError,
     CollectorException,
     CollectorConfigContentError,
     CollectorConfigurationException,
     CollectionSchedulerException,
+    EmptyConfigurationError,
     HypervisorCollectorException,
     HypervisorCollectorRetriesExhausted,
     GathererException,
     NoConfigFilesFoundError,
     SCCUploaderException,
+    SchedulerInvalidConfigError
 )
 from .config_manager import ConfigManager
 from .configuration import (BackendConfig, CollectorConfig, CredentialsConfig,
@@ -35,11 +38,14 @@ __all__ = [
     'CollectorConfigurationException',
     'CollectorConfigContentError',
     'CollectionSchedulerException',
+    'ConfigManagerException',
+    'EmptyConfigurationError',
     'HypervisorCollectorException',
     'HypervisorCollectorRetriesExhausted',
     'GathererException',
     'NoConfigFilesFoundError',
     'SCCUploaderException',
+    'SchedulerInvalidConfigError',
 
     # config_manager
     'ConfigManager',

--- a/src/scc_hypervisor_collector/api/exceptions.py
+++ b/src/scc_hypervisor_collector/api/exceptions.py
@@ -125,7 +125,7 @@ class HypervisorCollectorRetriesExhausted(HypervisorCollectorException):
     @property
     def retries(self) -> Any:
         """Retrieves the retries argument."""
-        return self._get_arg(2)
+        return self._get_arg(3)
 
     def __str__(self) -> str:
         return (

--- a/src/scc_hypervisor_collector/api/gatherer.py
+++ b/src/scc_hypervisor_collector/api/gatherer.py
@@ -5,12 +5,9 @@ The VHGather is a wrapper class for managing virtual-host-gatherer
 integration.
 """
 
-import logging
 from typing import (Any, cast, Dict, Optional, Sequence)
 
 from gatherer.gatherer import Gatherer
-
-LOG = logging.getLogger()
 
 
 class VHGatherer:

--- a/src/scc_hypervisor_collector/api/hypervisor_collector.py
+++ b/src/scc_hypervisor_collector/api/hypervisor_collector.py
@@ -25,8 +25,6 @@ from .exceptions import (
     HypervisorCollectorRetriesExhausted
 )
 
-LOG = logging.getLogger()
-
 
 class HypervisorCollector:
     """Hypervisor Collector for scc-hypervisor-collector
@@ -64,8 +62,9 @@ class HypervisorCollector:
 
     def __init__(self, backend: BackendConfig, retries: int = 3):
         """Initialiser for HypervisorCollector"""
+        self._log = logging.getLogger(__name__)
 
-        LOG.debug("backend=%s, retries=%d", repr(backend), retries)
+        self._log.debug("backend=%s, retries=%d", repr(backend), retries)
 
         # save the parameters
         self._backend: BackendConfig = backend
@@ -115,11 +114,14 @@ class HypervisorCollector:
             if results is not None:
                 break
 
-            LOG.debug("Backend %s, module %s, attempt %d failed",
-                      repr(self.backend.id), repr(self.backend.module),
-                      attempt)
+            self._log.debug("Backend %s, module %s, attempt %d failed",
+                            repr(self.backend.id), repr(self.backend.module),
+                            attempt)
 
         else:
+            self._log.error("Backend %s, module %s, query failed after "
+                            "%d attempts", repr(self.backend.id),
+                            repr(self.backend.module), attempt)
             # retry count exhausted without successfully retrieving any
             # results for specified backend.
             raise HypervisorCollectorRetriesExhausted(
@@ -129,8 +131,9 @@ class HypervisorCollector:
                 self.retries,
             )
 
-        LOG.debug("Backend %s, module %s, query succeeded after %d attempts",
-                  repr(self.backend.id), repr(self.backend.module), attempt)
+        self._log.debug("Backend %s, module %s, query succeeded after "
+                        "%d attempts", repr(self.backend.id),
+                        repr(self.backend.module), attempt)
 
         return results
 

--- a/src/scc_hypervisor_collector/api/scheduler.py
+++ b/src/scc_hypervisor_collector/api/scheduler.py
@@ -13,8 +13,6 @@ from .configuration import CollectorConfig
 from .exceptions import SchedulerInvalidConfigError
 from .hypervisor_collector import HypervisorCollector
 
-LOG = logging.getLogger()
-
 
 class CollectionScheduler:
     """Collection Scheduler for scc-hypervisor-collector.
@@ -43,8 +41,9 @@ class CollectionScheduler:
 
     def __init__(self, config: CollectorConfig):
         """Schedule collection of details from config specified backends."""
+        self._log = logging.getLogger(__name__)
 
-        LOG.debug("config=%s", repr(config))
+        self._log.debug("config=%s", repr(config))
 
         # sanity check the parameters
         if config is None:
@@ -63,14 +62,14 @@ class CollectionScheduler:
         # determine set of hypervisor types specified in configuration
         self._hypervisor_types: Set[str] = {b.module for b in config.backends}
 
-        LOG.debug("hv_types: %s", repr(self._hypervisor_types))
+        self._log.debug("hv_types: %s", repr(self._hypervisor_types))
 
         # instantiate collectors for each backend
         self._hypervisors: Sequence[HypervisorCollector] = [
             HypervisorCollector(b) for b in config.backends
         ]
 
-        LOG.debug("hvs: %s", repr(self._hypervisors))
+        self._log.debug("hvs: %s", repr(self._hypervisors))
 
         # group collectors by hypervisor type
         self._hypervisor_groups: Dict[str, Sequence[HypervisorCollector]] = {
@@ -78,7 +77,7 @@ class CollectionScheduler:
             for t in self._hypervisor_types
         }
 
-        LOG.debug("hv_groups: %s", repr(self._hypervisor_groups))
+        self._log.debug("hv_groups: %s", repr(self._hypervisor_groups))
 
     def _run_hv_type_queries(self, hv_type: str) -> None:
         """Query backends for each configured hypervisor of given type."""

--- a/tests/unit/test_scc_hypervisor_collector_cli.py
+++ b/tests/unit/test_scc_hypervisor_collector_cli.py
@@ -1,14 +1,12 @@
 import pytest
-import logging
 
 from scc_hypervisor_collector.api import exceptions
 
 class TestSCCHypervisorCollectorCLI:
     """Class for scc-hypervisor-collector cli tests"""
-
     def test_no_arguments(self, capsys, monkeypatch, scc_hypervisor_collector_cli):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector"])
-        with pytest.raises(exceptions.NoConfigFilesFoundError):
+        with pytest.raises(SystemExit):
             scc_hypervisor_collector_cli.main()
 
     def test_bad_option(self, capsys, monkeypatch, scc_hypervisor_collector_cli):
@@ -37,25 +35,27 @@ class TestSCCHypervisorCollectorCLI:
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--check", "--config", "tests/unit/data/config/default/default.yaml"])
         with pytest.raises(SystemExit):
             scc_hypervisor_collector_cli.main()
-        #need to add asssertions when logger is accessible
+        for record in caplog.records:
+            assert record.levelname != 'DEBUG' #default log level is INFO
 
     def test_check_option_failure(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--check", "--config-dir", "tests/unit/data/config/invalid"])
         with pytest.raises(SystemExit):
             scc_hypervisor_collector_cli.main()
-        #need to add asssertions when logger is accessible
+        for record in caplog.records:
+            assert record.levelname != 'DEBUG' #default log level is INFO
 
     def test_quiet_option(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--quiet", "--config", "tests/unit/data/config/default/default.yaml"])
-        with pytest.raises(exceptions.HypervisorCollectorRetriesExhausted):
+        with pytest.raises(SystemExit):
             scc_hypervisor_collector_cli.main()
-        #need to add asssertions when logger is accessible
+        for record in caplog.records:
+            assert record.levelname != 'DEBUG'
+        assert caplog.records[-1].levelname == 'ERROR' and 'query failed after 3 attempts' in caplog.text
 
     def test_verbose_option(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--verbose", "--config", "tests/unit/data/config/default/default.yaml"])
-        with pytest.raises(exceptions.HypervisorCollectorRetriesExhausted):
+        with pytest.raises(SystemExit):
             scc_hypervisor_collector_cli.main()
-        #need to add asssertions when logger is accessible
-
-
-
+        assert caplog.records[0].levelname == 'DEBUG'
+        assert caplog.records[-1].levelname == 'ERROR' and 'query failed after 3 attempts' in caplog.text


### PR DESCRIPTION
Changes include restructuring of logging to make
the logger object accessible so we can validate
log messages in the tests.

Also hide the stacktrace being shown to the
user on the terminal when an error occurs but
stacktrace is available in the log file.