### PR TITLE
Add systemd integration support to package build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,9 @@ ignore =
 	*.spec
 	*requirements.txt
 	bin/**
-	tests/**
 	examples/**
+	systemd/**
+	tests/**
 
 [tool:pytest]
 norecursedirs = 
@@ -25,10 +26,18 @@ norecursedirs =
 	.git
 	.tox
 	bin
+	systemd
 testpaths = tests
 
 [flake8]
-exclude = .venv,bin,.tox,.eggs,.git
+exclude =
+	.eggs
+	.git
+	.tox
+	.venv
+	bin
+	systemd
+	tests
 
 [coverage:report]
 fail_under = 90

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ from setuptools import find_packages, setup
 
 here = pathlib.Path(__file__).parent.resolve()
 
+
 # Get the version from the toplevel package __init__.py
 def get_version(pkg_path, version_file="__init__.py",
                 version_attr="__version__"):
@@ -35,6 +36,7 @@ def get_version(pkg_path, version_file="__init__.py",
         if line.startswith(version_attr):
             quote = "'" if "'" in line else '"'
             return line.split(quote)[1]
+
 
 pkg_name = "scc-hypervisor-collector"
 pkg_imp_name = pkg_name.replace('-', '_')
@@ -93,7 +95,8 @@ tox_requirements = [
 setup(
     name=pkg_name,
     version=pkg_version,
-    description="Collect hypervisor details for upload to SUSE Customer Center.",
+    description=("Collect hypervisor details for upload to "
+                 "SUSE Customer Center."),
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='https://github.com/SUSE/scc-hypervisor-collector',
@@ -135,6 +138,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     project_urls={
-        "Bug Tracker": "https://github.com/SUSE/scc-hypervisor-collector/issues",
+        "Bug Tracker":
+            "https://github.com/SUSE/scc-hypervisor-collector/issues",
     },
 )

--- a/systemd/scc-hypervisor-collector.service
+++ b/systemd/scc-hypervisor-collector.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=run scc-hypervisor-collector if valid config defined
+Documentation=man:scc-hypervisor-collector(1) man:scc-hypervisor-collector.service(8)
+
+[Service]
+Type=oneshot
+RemainAfterExit=false
+User=scchvc
+Group=scchvc
+ExecStart=scc-hypervisor-collector
+ExecCondition=scc-hypervisor-collector --check

--- a/systemd/scc-hypervisor-collector.timer
+++ b/systemd/scc-hypervisor-collector.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=update SCC daily with collecter hypervisor details
+Documentation=man:scc-hypervisor-collector(1) man:scc-hypervisor-collector.service(8)
+
+[Timer]
+OnBootSec=15m
+OnUnitActiveSec=1d
+RandomizedDelaySec=15m

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ skip_install = true
 commands =
     check-manifest
     python setup.py check -m -s
-    flake8 src
+    flake8
     mypy --disallow-untyped-defs \
          --check-untyped-defs \
          --ignore-missing-imports \


### PR DESCRIPTION
Add preliminary systemd service and timer scripts, under the systemd
top-level directory in the repo, that will be leveraged by the OBS
packaging workflow to setup the scc-hypervisor-collector to run as
the 'scchvc' service user on a daily basis, if valid configuration
has been defined.

Update the spec file to create multiple packages:
  * Base package just contains the systemd integration components
    and associated pre/post install/uninstall scripts to create
    the required 'scchvc' service user account.
  * The -common package contains the tool itself and the Python
    library package needed to support it.

Updated check-manifest and flake8 exclude lists to ignore relevant
directories, including newly added systemd directory.

Changed flake8 tox test to run against entire repo, excluding those
files and directories list in the exclude list.

Fixed some complaints from flake8 about the setup.py.