### PR TITLE
Tests for checking logs for sensitive information

### DIFF
--- a/src/scc_hypervisor_collector/api/config_manager.py
+++ b/src/scc_hypervisor_collector/api/config_manager.py
@@ -267,3 +267,8 @@ class ConfigManager:
             self._config_data = CollectorConfig(self._load_config(),
                                                 _check=self._check)
         return self._config_data
+
+    @property
+    def log(self) -> logging.Logger:
+        """Return the Logger object"""
+        return self._log

--- a/tests/unit/data/config/mock/config.yaml
+++ b/tests/unit/data/config/mock/config.yaml
@@ -16,13 +16,12 @@ backends:
     hostname: "vcenter.bogustest.net"
     port: 443
     username: "Administrator@test.net"
-    password: "test"
+    password: "3tjdla3gEP4WqkPd"
 
 
   # A Libvirt Hypervisor node
   - id: "libvirt1"
     module: "Libvirt"
     uri: "qemu+ssh://vagrant@libvirt.bogustest.net/system"
-    #remove the following entries but for now since it's marked as required, leaving it as is
     sasl_username: "tux"
-    sasl_password: "tux"
+    sasl_password: "3tjdla3gEP4WqkPd"

--- a/tests/unit/test_scc_hypervisor_collector_cli.py
+++ b/tests/unit/test_scc_hypervisor_collector_cli.py
@@ -1,6 +1,7 @@
+import mock
 import pytest
 
-from scc_hypervisor_collector.api import exceptions
+from tests import utils
 
 class TestSCCHypervisorCollectorCLI:
     """Class for scc-hypervisor-collector cli tests"""
@@ -59,3 +60,15 @@ class TestSCCHypervisorCollectorCLI:
             scc_hypervisor_collector_cli.main()
         assert caplog.records[0].levelname == 'DEBUG'
         assert caplog.records[-1].levelname == 'ERROR' and 'query failed after 3 attempts' in caplog.text
+
+    def test_verbose_sensitive_field(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
+        monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--verbose", "--config", "tests/unit/data/config/mock/config.yaml"])
+        with pytest.raises(SystemExit):
+            scc_hypervisor_collector_cli.main()
+        assert "3tjdla3gEP4WqkPd" not in caplog.text
+
+    def test_sensitive_field(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
+        monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector","--config", "tests/unit/data/config/mock/config.yaml"])
+        with pytest.raises(SystemExit):
+            scc_hypervisor_collector_cli.main()
+        assert "3tjdla3gEP4WqkPd" not in caplog.text


### PR DESCRIPTION
Introduced a new fixture to create the hypervisor collector
with different log levels and exercise the test against
these different log levels to validate we are not leaking
any sensitive information. We set the log level
of the root in the fixture so all the modules
inherit the log level being tested against.

Fixes #8