### PR TITLE
Update log message format

### DIFF
--- a/src/scc_hypervisor_collector/cli/__init__.py
+++ b/src/scc_hypervisor_collector/cli/__init__.py
@@ -29,12 +29,8 @@ def create_logger(level: str,
     logger = logging.getLogger()
     logger.setLevel(level)
 
-    if level == 'DEBUG':
-        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s'
-                                      ' - %(message)s')
-    else:
-        formatter = logging.Formatter('%(levelname)s - %(message)s')
-
+    fmt_str = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    formatter = logging.Formatter(fmt_str)
     loghandler: Any = None
     if logfile:
         loghandler = PermissionsRotatingFileHandler(logfile,
@@ -42,6 +38,8 @@ def create_logger(level: str,
                                                     backupCount=5)
     else:
         loghandler = logging.StreamHandler()
+        if level != 'DEBUG':
+            formatter = logging.Formatter('%(levelname)s - %(message)s')
 
     loghandler.setFormatter(formatter)
     logger.addHandler(loghandler)


### PR DESCRIPTION
Include timestamps in the stdout/stderr stream
log messages when running in verbose mode.

For file based, timestamps will be
included always