### PR TITLE
Tweak packaging

### DIFF
--- a/scc-hypervisor-collector.spec
+++ b/scc-hypervisor-collector.spec
@@ -60,6 +60,7 @@ run the scc-hypervisor-collector on a regular basis.
 Summary:        Tool to collect and upload hypervisor details to SUSE Customer Care
 Group:          System/Management
 Requires:       %{python_module PyYAML}
+Requires:       openssh-clients
 Requires:       virtual-host-gatherer-Libvirt
 Requires:       virtual-host-gatherer-VMware
 

--- a/systemd/scc-hypervisor-collector.timer
+++ b/systemd/scc-hypervisor-collector.timer
@@ -6,3 +6,6 @@ Documentation=man:scc-hypervisor-collector(1) man:scc-hypervisor-collector.servi
 OnBootSec=15m
 OnUnitActiveSec=1d
 RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Ensure that we have an Install section specifying that our timer is
WantedBy=timers.target which will allow our time to be enabled.

The scc-hypervisor-collector libvirt SSH URI support requires an ssh
client.

Relates: #11