### PR TITLE
systemd settings tweaks and add OBS container build support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ tox driven testing. You will still need to install the relevant versions of
 the Python interpreter using `pyenv install <version>` for them to actually be
 available for use by `tox`.
 
+# Packaging Support
+
+An [RPM spec file](scc-hypervisor-collector.spec) is provided which is ready
+to be used by the openSUSE Build Service (OBS).
+
+Additionally a [Dockerfile](container/Dockerfile) (suitable for building a
+container image in OBS) and an accompanying [entrypoint script](container/entrypoint.bash)
+are provided in the [container directory](container).
+
 # The scc-hypervisor-collector design
 The tool is broken down into a number of component APIs which are implemented as
 subpackages within the main `scc-hypervisor-collector` package.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,9 +1,6 @@
 #!BuildTag: suse/scc-hypervisor-collector:15.3
 FROM suse/sle15:15.3
 
-#USER wwwrun
-#WORKDIR /srv/www
-
 # Put additional files into container
 COPY entrypoint.bash /root/
 RUN chmod 700 /root/entrypoint.bash

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,19 @@
+#!BuildTag: suse/scc-hypervisor-collector:15.3
+FROM suse/sle15:15.3
+
+#USER wwwrun
+#WORKDIR /srv/www
+
+# Put additional files into container
+COPY entrypoint.bash /root/
+RUN chmod 700 /root/entrypoint.bash
+
+# Work around https://github.com/openSUSE/obs-build/issues/487
+RUN zypper install -y sles-release
+
+# Install further packages using zypper
+RUN zypper install -y scc-hypervisor-collector-common
+
+# This command will get executed on container start by default
+ENTRYPOINT ["/root/entrypoint.bash"]
+CMD ["--config_dir", "/var/lib/scchvc/.config/scc-hypervisor-collector"]

--- a/container/entrypoint.bash
+++ b/container/entrypoint.bash
@@ -1,0 +1,49 @@
+#!/bin/bash -eu
+
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# scc-hypervisor-collector configuration should be available under
+# /var/lib/scchvc, so we need to ensure that we have a user defined
+# in our container environment that matches the user id of that mount
+# point.
+
+shcuser=scchvc
+name=scc-hypervisor-collector
+_localstatedir=/var
+_svcdir=${_localstatedir}/lib/${shcuser}
+
+update-ca-certificates
+
+if [[ ! -d ${_svcdir} ]]; then
+    echo "Error: no ${_svcdir} directory found; did you bind mount the service account dir to ${_svcdir}?"
+    exit 1
+fi
+
+uid_gid=(
+    $(stat -c '%u %g' ${_svcdir})
+)
+
+# ensure that the required group exists or add it with matching gid
+# if needed
+getent group ${shcuser} >/dev/null || groupadd \
+    -r \
+    -g ${uid_gid[1]} \
+    ${shcuser}
+
+# ensure that the required user exists or add it with matching udi
+# if needed
+getent passwd ${shcuser} >/dev/null || useradd \
+    -r \
+    -g ${shcuser} \
+    -u ${uid_gid[0]} \
+    -d ${_svcdir} \
+    -s /sbin/nologin \
+    -c "user for ${name}" ${shcuser}
+
+cmd_args=(
+    ${name}
+    "${@}"
+)
+
+set -vx
+su - ${shcuser} --shell /bin/bash -c "${cmd_args[*]}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ ignore =
 	*.spec
 	*requirements.txt
 	bin/**
+	container/**
 	examples/**
 	systemd/**
 	tests/**
@@ -26,6 +27,7 @@ norecursedirs =
 	.git
 	.tox
 	bin
+	container
 	systemd
 testpaths = tests
 
@@ -36,6 +38,7 @@ exclude =
 	.tox
 	.venv
 	bin
+	container
 	systemd
 	tests
 

--- a/systemd/scc-hypervisor-collector.service
+++ b/systemd/scc-hypervisor-collector.service
@@ -7,5 +7,5 @@ Type=oneshot
 RemainAfterExit=false
 User=scchvc
 Group=scchvc
-ExecStart=scc-hypervisor-collector
-ExecCondition=scc-hypervisor-collector --check
+ExecStart=/usr/bin/timeout 60m /usr/bin/scc-hypervisor-collector
+ExecCondition=/usr/bin/scc-hypervisor-collector --check

--- a/systemd/scc-hypervisor-collector.timer
+++ b/systemd/scc-hypervisor-collector.timer
@@ -3,8 +3,7 @@ Description=update SCC daily with collecter hypervisor details
 Documentation=man:scc-hypervisor-collector(1) man:scc-hypervisor-collector.service(8)
 
 [Timer]
-OnBootSec=15m
-OnUnitActiveSec=1d
+OnCalendar=daily
 RandomizedDelaySec=15m
 
 [Install]


### PR DESCRIPTION
Add support for building a container with the tool installed in the
openSUSE Build Service.

Also in the systemd service run the scc-hypervisor-collector using
the timeout command, with a 1 hour timeout, to ensure that a hanging
network connection doesn't permanently stall the scheduling of the
service.

Switch the systemd timer script to trigger running the associated
service on a daily basis.

Update README.md to reflect recent packaging related changes.

Relates: #11
Fixes: #34