### PR TITLE
entrypoint.bash installs certs from ~scchvc/certs

### DIFF
--- a/container/entrypoint.bash
+++ b/container/entrypoint.bash
@@ -11,6 +11,9 @@ shcuser=scchvc
 name=scc-hypervisor-collector
 _localstatedir=/var
 _svcdir=${_localstatedir}/lib/${shcuser}
+_certdir=${_svcdir}/certs
+
+[ -d ${_certdir} ] && cp ${_certdir}/* /etc/pki/trust/anchors
 
 update-ca-certificates
 


### PR DESCRIPTION
Update the entrypoint.bash script to copy any files found in the
~scchvc/certs directory to the /etc/pki/trust/anchors before it
runs update-ca-certificates.