### PR TITLE
Continue processing remaining backends upon failure on any

### DIFF
--- a/src/scc_hypervisor_collector/api/hypervisor_collector.py
+++ b/src/scc_hypervisor_collector/api/hypervisor_collector.py
@@ -190,20 +190,14 @@ class HypervisorCollector:
     @property
     def pending(self) -> bool:
         """Return True if the backend status is pending"""
-        if self._status == "pending":
-            return True
-        return False
+        return self._status == "pending"
 
     @property
     def succeeded(self) -> bool:
         """Return True if the backend status is success"""
-        if self._status == "success":
-            return True
-        return False
+        return self._status == "success"
 
     @property
     def failed(self) -> bool:
         """Return True if the backend status is failure"""
-        if self._status == "failure":
-            return True
-        return False
+        return self._status == "failure"

--- a/src/scc_hypervisor_collector/api/hypervisor_collector.py
+++ b/src/scc_hypervisor_collector/api/hypervisor_collector.py
@@ -21,9 +21,6 @@ import logging
 from typing import (cast, Dict, Optional, Sequence)
 
 from .configuration import BackendConfig
-from .exceptions import (
-    HypervisorCollectorRetriesExhausted
-)
 
 
 class HypervisorCollector:
@@ -33,7 +30,7 @@ class HypervisorCollector:
     using the virtual-host-gatherer to perform the query.
 
     Arguments:
-        backend (BackendConfigh): the backend config to be managed
+        backend (BackendConfig): the backend config to be managed
             by this HypervisorCollector instance.
 
         retries (int, default 3): the max number of retries to be
@@ -76,6 +73,8 @@ class HypervisorCollector:
         self._results: Optional[Dict] = None
         self._details: Optional[Dict] = None
 
+        self._status = 'pending'
+
     @property
     def backend(self) -> BackendConfig:
         """Return the associated backend config."""
@@ -112,6 +111,7 @@ class HypervisorCollector:
             # If we got a valid result for the backend then break out
             # of the retry loop.
             if results is not None:
+                self._status = 'success'
                 break
 
             self._log.debug("Backend %s, module %s, attempt %d failed",
@@ -119,27 +119,21 @@ class HypervisorCollector:
                             attempt)
 
         else:
+            self._status = 'failure'
+            results = {}
             self._log.error("Backend %s, module %s, query failed after "
                             "%d attempts", repr(self.backend.id),
                             repr(self.backend.module), attempt)
-            # retry count exhausted without successfully retrieving any
-            # results for specified backend.
-            raise HypervisorCollectorRetriesExhausted(
-                "Failed to retrieve any data after exhausing all retries",
-                self.backend.id,
-                self.backend.module,
-                self.retries,
-            )
-
-        self._log.debug("Backend %s, module %s, query succeeded after "
-                        "%d attempts", repr(self.backend.id),
-                        repr(self.backend.module), attempt)
+        if self.succeeded:
+            self._log.debug("Backend %s, module %s, query succeeded after "
+                            "%d attempts", repr(self.backend.id),
+                            repr(self.backend.module), attempt)
 
         return results
 
     def run(self) -> None:
         """Run the backend query if not already run."""
-        if self._results is None:
+        if self._results is None and self.pending:
             # Run the backend query
             self._results = self._query_backend()
 
@@ -192,3 +186,24 @@ class HypervisorCollector:
             }
 
         return cast(Dict, self._details)
+
+    @property
+    def pending(self) -> bool:
+        """Return True if the backend status is pending"""
+        if self._status == "pending":
+            return True
+        return False
+
+    @property
+    def succeeded(self) -> bool:
+        """Return True if the backend status is success"""
+        if self._status == "success":
+            return True
+        return False
+
+    @property
+    def failed(self) -> bool:
+        """Return True if the backend status is failure"""
+        if self._status == "failure":
+            return True
+        return False

--- a/tests/unit/test_scc_hypervisor_collector_cli.py
+++ b/tests/unit/test_scc_hypervisor_collector_cli.py
@@ -48,27 +48,23 @@ class TestSCCHypervisorCollectorCLI:
 
     def test_quiet_option(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--quiet", "--config", "tests/unit/data/config/default/default.yaml"])
-        with pytest.raises(SystemExit):
-            scc_hypervisor_collector_cli.main()
+        scc_hypervisor_collector_cli.main()
         for record in caplog.records:
             assert record.levelname != 'DEBUG'
         assert caplog.records[-1].levelname == 'ERROR' and 'query failed after 3 attempts' in caplog.text
 
     def test_verbose_option(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--verbose", "--config", "tests/unit/data/config/default/default.yaml"])
-        with pytest.raises(SystemExit):
-            scc_hypervisor_collector_cli.main()
+        scc_hypervisor_collector_cli.main()
         assert caplog.records[0].levelname == 'DEBUG'
         assert caplog.records[-1].levelname == 'ERROR' and 'query failed after 3 attempts' in caplog.text
 
     def test_verbose_sensitive_field(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--verbose", "--config", "tests/unit/data/config/mock/config.yaml"])
-        with pytest.raises(SystemExit):
-            scc_hypervisor_collector_cli.main()
+        scc_hypervisor_collector_cli.main()
         assert "3tjdla3gEP4WqkPd" not in caplog.text
 
     def test_sensitive_field(self, capsys, monkeypatch, scc_hypervisor_collector_cli, caplog):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector","--config", "tests/unit/data/config/mock/config.yaml"])
-        with pytest.raises(SystemExit):
-            scc_hypervisor_collector_cli.main()
+        scc_hypervisor_collector_cli.main()
         assert "3tjdla3gEP4WqkPd" not in caplog.text


### PR DESCRIPTION
Currently we stop if there is any failure with
a backend. This change will support contiuning
processing of the remaining backends even if
there is any failure in one of the backends.

The results of a failed backend is set to empty {}