### PR TITLE
Add additional documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.watcherExclude": {
+    "**/.venv/**": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Additionally a [Dockerfile](container/Dockerfile) (suitable for building a
 container image in OBS) and an accompanying [entrypoint script](container/entrypoint.bash)
 are provided in the [container directory](container).
 
+# Running the scc-hypervisor-collector
+
+See the [man pages](doc/man) for details about running the command locally.
+
+See [Security Recommendations](doc/Security.md) for further details about
+ensuring the configuration settings and runtime environment for the command
+are correctly setup.
+
+See [Container Deployment](doc/Container_Deployment.md) for details on how to
+run the command using a container image built using the [Dockerfile](container/Dockerfile)
+and the [Open Build Service](https://build.opensuse.org).
+
 # The scc-hypervisor-collector design
 The tool is broken down into a number of component APIs which are implemented as
 subpackages within the main `scc-hypervisor-collector` package.

--- a/container/entrypoint.bash
+++ b/container/entrypoint.bash
@@ -13,7 +13,7 @@ _localstatedir=/var
 _svcdir=${_localstatedir}/lib/${shcuser}
 _certdir=${_svcdir}/certs
 
-[ -d ${_certdir} ] && cp ${_certdir}/* /etc/pki/trust/anchors
+[ -d ${_certdir} ] && cp -a ${_certdir}/* /etc/pki/trust/anchors
 
 update-ca-certificates
 

--- a/container/entrypoint.bash
+++ b/container/entrypoint.bash
@@ -48,5 +48,4 @@ cmd_args=(
     "${@}"
 )
 
-set -vx
 su - ${shcuser} --shell /bin/bash -c "${cmd_args[*]}"

--- a/doc/Container_Deployment.md
+++ b/doc/Container_Deployment.md
@@ -1,0 +1,89 @@
+# Container based deployment
+
+The provided [Dockerfile](../container/Dockerfile) can be used to
+build a SUSE Linux Enterprise 15 based container image, leveraging
+[entrypoint.bash](../container/entrypoint.bash) script as the entry
+point to ensure that the container runtime environment is set up
+correctly before running the `scc-hypervisor-collector` tool.
+
+## Bind Mount Volumes
+
+The container expects that a properly setup directory will be bind
+mounted on `/var/lib/scchvc`.
+
+This directory should contain the following:
+
+* a `.config/scc-hypervisor-collector` sub-directory, with desired
+  configuration settings.
+* optionally a `.ssh` sub-directory with relevant SSH private key
+  supporting passwordless access to any `qemu+ssh` protocol based
+  Libvirt connection URIs specified in the configuration settings.
+* optionally a `certs` directory containing any certs that are
+  needed to access any HTTPS protocol based hypervisor connection
+  URLs.
+
+This directory, and all of the sub-directories and contained files,
+should be owned by, and accessible only to, the same non-root user,
+per the `scc-hypervisor-collector` [Security Recommendations](Security.md).
+
+## Entrypoint
+
+The [entrypoint.bash](../container/entrypoint.bash) script expects
+to find a host directory bind mounted to `/var/lib/scchvc` that is
+owned by, and accessible only to an appropriate non-root user.
+
+The script will perform the following actions:
+
+* determine the user and group ids associated with the `/var/lib/scchvc`
+  and dynamically create a local `scchvc` user and associated `scchvc`
+  group with the same user and group ids within the container runtime,
+  whose home directory is `/var/lib/scchvc`.
+* if any certs have been provided in the `/var/lib/scchvc/certs` directory
+  they will be copied to the `/etc/pki/trust/anchors` directory within
+  the container runtime, and `update-ca-certificates` will be run to
+  ensure that they are available for HTTPS protocol connection verification.
+* run the `scc-hypervisor-collector` as the dynamically created `scchvc`
+  user, using specified, or default if not provided, container run
+  arguments.
+
+# Building the container
+
+Currently the [Dockerfile](../container/Dockerfile) is intended to be
+leveraged as part of an [Open Build Service](https://build.opensuse.org)
+SLE 15 SP3 based container build.
+
+# Container based workflow
+
+The [Dockerfile](../container/Dockerfile) is intended to be run against
+a directory that has been setup appropriately to act as the home directory
+of a user that will run the `scc-hypervisor-collector` command, as defined
+above.
+
+This directory should be bind mounted to the `/var/lib/scchvc` directory
+when running the tool via a container.
+
+Built containers have been tested successfully using `podman` and `docker`.
+
+## Example container run
+
+Using `/home/someuser`, which has been setup appropriately with the
+necessary configuration settings, appropriate certs and SSH private
+keys, and the built container, the `scc-hypervisor-collector` check
+mode can be run via the container using the following command (replace
+`podman` with `docker` if needed):
+
+```
+% sudo podman run --rm \
+    -v /home/someuser:/var/lib/scchvc \
+    ${CONTAINER_IMAGE_REGISTRY_URL} \
+    --check
+```
+
+If the configuration check passes you can run the tool against the
+configuration using:
+
+```
+% sudo podman run --rm \
+    -v /home/someuser:/var/lib/scchvc \
+    ${CONTAINER_IMAGE_REGISTRY_URL}
+```

--- a/doc/Security.md
+++ b/doc/Security.md
@@ -1,0 +1,60 @@
+# scc-hypervisor-collector Security Fundamentals
+
+The `scc-hypervisor-collector` tool requires the use of sensitive
+information, such as SUSE Customer Center (SCC) organisation, 
+hypervisor login credentials, or access to SSH private keys, to
+be able to collect the relevant details from hypervisor backends
+specified in it's configuration and upload them to the SCC.
+
+## Non-root user requirement
+
+As the tool is intended to run without any special privileges it
+will fail if it detects that it is running as the `root` user.
+
+## Configuration settings
+
+The `scc-hypervisor-collector` imposes the following restriction on
+configuration settings:
+
+* configuration files and directories must be owned by, and accessible
+  only to, the user running the tool
+
+This applies to all configuration files, whether specified directly via
+the `--config` option, or found under the `--config-dir` directory,
+which defaults to `~/.config/scc-hypervisor-collector`.
+
+## Password SSH Keys
+
+The SSH tools themselves impose restrictions on the access permissions
+and ownership of SSH private keys, similar to those that are specified
+above for the `scc-hypervisor-collector`; failure to follow those
+recommendations will lead to errors when attempting to leverage the
+`qemu+ssh` protocol in Libvirt connection URIs.
+
+## Log Messages and Files
+
+The `scc-hypervisor-collector` depends upon external libraries to
+collect the hypervisor details. As such it is possible that some of
+those dependencies may contain code that could leak sensitive data
+under certain failure scenarios. Similarly, a bug in the tool itself
+could result in similar leakage.
+
+Therefore, to mitigate the risk of exposing any sensitive data in
+log messages, the log file (default `~/scc-hypervisor-collect.log`)
+must be owned by, and only accessible to, the user running the tool.
+
+Note that care has been taken to avoid leaking sensitive data via log
+messages or to the standard output; when loaded configuration data is
+rendered for display, sensitive values will be replaced by `********`.
+
+Similarly our CI unit tests include checking for leaks of these
+sensitive data fields during simulated success and failure scenaios.
+
+## Hypervisor Credentials and SSH Keys
+
+It is strongly recommended that any hypervisor access credentials,
+or passwordless SSH keys, be associated with minimally privileged
+accounts that can only be used to retrieve the relevant details.
+
+This will help further mitigate any risks that may be associated
+with inadvertently exposed credentials.

--- a/doc/Security.md
+++ b/doc/Security.md
@@ -23,7 +23,7 @@ This applies to all configuration files, whether specified directly via
 the `--config` option, or found under the `--config-dir` directory,
 which defaults to `~/.config/scc-hypervisor-collector`.
 
-## Password SSH Keys
+## Passwordless SSH Keys
 
 The SSH tools themselves impose restrictions on the access permissions
 and ownership of SSH private keys, similar to those that are specified

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ ignore =
 	tox.ini
 	*.spec
 	*requirements.txt
+	.venv/**
+	.vscode/**
 	bin/**
 	container/**
 	doc/**
@@ -24,6 +26,7 @@ ignore =
 [tool:pytest]
 norecursedirs = 
 	.venv
+	.vscode
 	.eggs
 	.git
 	.tox
@@ -39,6 +42,7 @@ exclude =
 	.git
 	.tox
 	.venv
+	.vscode
 	bin
 	container
 	doc


### PR DESCRIPTION
Add Security.md describing the security recommendations and requirements
for the scc-hypervisor-collector.

Add Container_Deployment.md outlining how to leverage a container image
to run scc-hypervisor-collector.

Update README.md to reference these new docs.

Copy directory hierarchy when copy certs from /var/lib/scchvc/certs into
container's /etc/pki/trust/anchors, and remove debug settings from the
entrypoint.sh.

Include a .vscode/settings file that exludes the .venv directory from
the watch list for changes. Also exclude the .vscode directory in the
relevant settings in setup.cfg.
