### PR TITLE
Skip CLI credentials check if NO_NETWORK_ACCESS env var set

### DIFF
--- a/scc-hypervisor-collector.spec
+++ b/scc-hypervisor-collector.spec
@@ -101,6 +101,7 @@ chmod -R g-rwx,o-rwx examples
 %{buildroot}%{_bindir}/%{name} --check --config examples/shc_cfg.yaml
 
 # run tests
+export NO_NETWORK_ACCESS=true
 pytest -vv
 
 %pre

--- a/tests/unit/test_scc_hypervisor_collector_cli.py
+++ b/tests/unit/test_scc_hypervisor_collector_cli.py
@@ -1,4 +1,7 @@
+import os
 import pytest
+
+no_network_access = (os.environ.get('NO_NETWORK_ACCESS', 'False').lower() in ['1', 'yes', 'true'])
 
 class TestSCCHypervisorCollectorCLI:
     """Class for scc-hypervisor-collector cli tests"""
@@ -114,6 +117,7 @@ class TestSCCHypervisorCollectorCLI:
             scc_hypervisor_collector_cli.main()
         assert "No backends specified in config!" in caplog.text
 
+    @pytest.mark.skipif(no_network_access, reason="No network available")
     def test_scc_credentials_check_option(self, capsys, monkeypatch, scc_hypervisor_collector_cli):
         monkeypatch.setattr("sys.argv", ["scc-hypervisor-collector", "--scc-credentials-check",  "--config", "tests/unit/data/config/mock/config.yaml"])
         with pytest.raises(SystemExit):


### PR DESCRIPTION
The build service doesn't permit external network access so we need to skip the SCC credentials check CLI test when building the package.

The spec file sets the NO_NETWORK_ACCESS env var to true before it runs the pytests, and the pytests check if that env var is set, and skip the test if needed.