### PR TITLE
Promote optionalVmData fields to siblings of vm_name in properties

### DIFF
--- a/src/scc_hypervisor_collector/api/hypervisor_collector.py
+++ b/src/scc_hypervisor_collector/api/hypervisor_collector.py
@@ -175,10 +175,10 @@ class HypervisorCollector:
                     },
                     "systems": [{
                         "uuid": u,
-                        "properties": {
-                            "vm_name": v,
-                            "data": dict(tuple(i['optionalVmData'][v].items()))
-                        }
+                        "properties": dict(
+                            [("vm_name", v)] +
+                            list(i['optionalVmData'][v].items())
+                        )
                     } for v, u in i['vms'].items()],
                 } for h, i in self.results.items()]
             }


### PR DESCRIPTION
Rather than storing the optionalVmData attributes in a 'data' hash under the 'properties' hash, we will include them directly in the 'properties' hash.