### PR TITLE
Make SCC server url configurable

### DIFF
--- a/src/scc_hypervisor_collector/api/configuration.py
+++ b/src/scc_hypervisor_collector/api/configuration.py
@@ -366,16 +366,23 @@ class BackendConfig(GeneralConfig):
 class SccCredsConfig(GeneralConfig):
     """Hypervisor Collector SCC credentials settings.
 
-    The SCC credentials configuration settings hold the following
-    settings:
+    The SCC credentials configuration settings must provide the following
+    entries:
       * username
       * password
+
+    Additionally the SCC credentials settings can provide a url entry that
+    specifies an alternate SCC server to be used for uploading collected
+    details.
 
     Read-only properties are defined for each setting.
 
     Special properties:
         username: The SCC Account username
         password: The SCC Account password
+
+    Optional properties:
+        url: The SCC server url to use, defaults to 'https://scc.suse.com'
     """
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -420,6 +427,12 @@ class SccCredsConfig(GeneralConfig):
         """The SCC Account password."""
 
         return self['password']
+
+    @property
+    def url(self) -> str:
+        """The SCC server url."""
+
+        return self.get('url', 'https://scc.suse.com')
 
 
 class CredentialsConfig(GeneralConfig):

--- a/src/scc_hypervisor_collector/api/uploader.py
+++ b/src/scc_hypervisor_collector/api/uploader.py
@@ -8,6 +8,7 @@ credentials.
 import json
 import logging
 import gzip
+from typing import Optional
 from importlib_metadata import version as get_package_version
 import requests
 from requests.exceptions import RequestException
@@ -20,9 +21,13 @@ class SCCUploader:
     """SCC Uploader for scc-hypervisor-collector."""
 
     def __init__(self, scc_creds: SccCredsConfig,
-                 scc_base_url: str = 'https://scc.suse.com'):
+                 scc_base_url: Optional[str] = None):
         """Initialiser for SCCUploader"""
         self._log = logging.getLogger(__name__)
+
+        # handle default parameters
+        if scc_base_url is None:
+            scc_base_url = scc_creds.url
 
         # save the parameters
         self._scc_creds = scc_creds

--- a/tests/unit/data/config/scc_url/default.yaml
+++ b/tests/unit/data/config/scc_url/default.yaml
@@ -1,0 +1,27 @@
+---
+
+# Credentials
+credentials:
+  scc:
+    username: "default_scc_username"
+    password: "default_scc_password"
+    url: "https://scc.example.com"
+
+# Hypervisor Backends
+backends:
+
+  # A VCenter example
+  - id: "default_vmware_1"
+    module: "VMware"
+    hostname: "vcenter1.example.com"
+    port: 443
+    username: "VMware_Account_Username"
+    password: "VMware_Account_Password"
+
+
+  # A Libvirt Hypervisor node
+  - id: "default_libvirt_1"
+    module: "Libvirt"
+    uri: "qemu+ssh:///system"
+    sasl_username: "Libvirt_Account_Username"
+    sasl_password: "Libvirt_Account_Password"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,6 +13,15 @@ class TestConfigManager:
         assert config_data.get('credentials')['scc']['username'] == 'default_scc_username'
         assert config_data.get('credentials')['scc']['password'] == 'default_scc_password'
 
+    @pytest.mark.config('tests/unit/data/config/scc_url/default.yaml', None)
+    def test_scc_server_url_specified(self, config_manager):
+        assert config_manager.config_data.credentials.scc.url != 'https://scc.suse.com'
+        assert config_manager.config_data.credentials.scc.url == 'https://scc.example.com'
+
+    @pytest.mark.config('tests/unit/data/config/default/default.yaml', None)
+    def test_scc_server_url_not_specified(self, config_manager):
+        assert config_manager.config_data.credentials.scc.url == 'https://scc.suse.com'
+
     @pytest.mark.config(None, 'tests/unit/data/config/empty')
     def test_empty_config_load(self, config_manager):
         with pytest.raises(exceptions.EmptyConfigurationError) as excinfo:


### PR DESCRIPTION
To aid in testing against development environment instances of the SCC, allow the target end point to be configured is the SCC credentials.

Added unit tests to validate that the default value is returned when no url value is specified in the config, and that the provided value is returned when a url value is specified in the config.

This change can be backed out in the long run if desired.