### PR TITLE
Implement file save/upload mechanisms

### DIFF
--- a/src/scc_hypervisor_collector/__init__.py
+++ b/src/scc_hypervisor_collector/__init__.py
@@ -14,14 +14,22 @@ the SUSE Customer Center.
 See 'ConfigManager' for details on configuration data setup.
 """
 
-from .api import (ConfigManager, CollectionScheduler, SCCUploader)
+from .api import (
+    check_permissions,
+    ConfigManager,
+    CollectionResults,
+    CollectionScheduler,
+    SCCUploader
+)
 
 
 __author = 'Fergal Mc Carthy <fmccarthy@suse.com>'
 __version__ = '0.0.3'
 
 __all__ = [
+    'check_permissions',
     'ConfigManager',
     'CollectionScheduler',
+    'CollectionResults',
     'SCCUploader'
 ]

--- a/src/scc_hypervisor_collector/api/__init__.py
+++ b/src/scc_hypervisor_collector/api/__init__.py
@@ -9,39 +9,48 @@ from .exceptions import (
     ConfigManagerError,
     ConfigManagerException,
     ConflictingBackendsError,
+    CollectionResultsInvalidData,
+    CollectionSchedulerException,
     CollectorException,
     CollectorConfigContentError,
     CollectorConfigurationException,
-    CollectionSchedulerException,
+    CollectorUtilException,
     EmptyConfigurationError,
+    FilePermissionsError,
     HypervisorCollectorException,
     GathererException,
     NoConfigFilesFoundError,
+    ResultsFilePermissionsError,
     SCCUploaderException,
-    SchedulerInvalidConfigError
+    SchedulerInvalidConfigError,
 )
 from .config_manager import ConfigManager
 from .configuration import (BackendConfig, CollectorConfig, CredentialsConfig,
                             GeneralConfig, SccCredsConfig)
 from .gatherer import VHGatherer
-from .hypervisor_collector import HypervisorCollector
-from .scheduler import CollectionScheduler
+from .hypervisor_collector import HypervisorCollector, HypervisorDetails
+from .scheduler import CollectionResults, CollectionScheduler
 from .uploader import SCCUploader
+from .util import check_permissions
 
 __all__ = [
     # exceptions
     'BackendConfigError',
     'ConfigManagerError',
     'ConflictingBackendsError',
+    'CollectionResultsInvalidData',
+    'CollectionSchedulerException',
     'CollectorException',
     'CollectorConfigurationException',
     'CollectorConfigContentError',
-    'CollectionSchedulerException',
+    'CollectorUtilException',
     'ConfigManagerException',
     'EmptyConfigurationError',
+    'FilePermissionsError',
     'HypervisorCollectorException',
     'GathererException',
     'NoConfigFilesFoundError',
+    'ResultsFilePermissionsError',
     'SCCUploaderException',
     'SchedulerInvalidConfigError',
 
@@ -60,10 +69,15 @@ __all__ = [
 
     # hypervisor_collector
     'HypervisorCollector',
+    'HypervisorDetails',
 
     # scheduler
+    'CollectionResults',
     'CollectionScheduler',
 
-    # scc_uploader
+    # uploader
     'SCCUploader',
+
+    # util
+    'check_permissions',
 ]

--- a/src/scc_hypervisor_collector/api/exceptions.py
+++ b/src/scc_hypervisor_collector/api/exceptions.py
@@ -104,6 +104,14 @@ class HypervisorCollectorException(CollectorException):
 
 
 # scheduler errors
+class CollectionResultsException(CollectorException):
+    """Base exception class for results exceptions."""
+
+
+class CollectionResultsInvalidData(CollectionResultsException):
+    """Invalid results provided for upload."""
+
+
 class CollectionSchedulerException(CollectorException):
     """Base exception class for scheduler exceptions."""
 
@@ -115,3 +123,20 @@ class SchedulerInvalidConfigError(CollectionSchedulerException):
 # uploader errors
 class SCCUploaderException(CollectorException):
     """Base exception class for uploader exceptions."""
+
+
+# util errors
+class CollectorUtilException(CollectorException):
+    """Base exception class for util exceptions."""
+
+
+class FilePermissionsError(CollectorUtilException):
+    """Invalid file permissions."""
+
+
+class ConfigFilePermissionsError(FilePermissionsError):
+    """Invalid config file permissions."""
+
+
+class ResultsFilePermissionsError(FilePermissionsError):
+    """Invalid config file permissions."""

--- a/src/scc_hypervisor_collector/api/uploader.py
+++ b/src/scc_hypervisor_collector/api/uploader.py
@@ -8,13 +8,12 @@ credentials.
 import json
 import logging
 import gzip
-from typing import Optional
+from typing import (Dict, Optional)
 from importlib_metadata import version as get_package_version
 import requests
 from requests.exceptions import RequestException
 
 from .configuration import SccCredsConfig
-from .hypervisor_collector import HypervisorCollector
 
 
 class SCCUploader:
@@ -43,13 +42,13 @@ class SCCUploader:
         }
         self.scc_base_url = scc_base_url
 
-    def upload(self, hv: HypervisorCollector,
+    def upload(self, details: Dict, backend: str,
                path: str =
                '/connect/organizations/virtualization_hosts') -> None:
         """ Upload the collected details to SCC"""
         headers = self.headers
         headers.update({'Content-Encoding': 'gzip'})
-        zipped_payload = gzip.compress(json.dumps(hv.details).encode('utf-8'))
+        zipped_payload = gzip.compress(json.dumps(details).encode('utf-8'))
 
         try:
             response = requests.put(self.scc_base_url + path,
@@ -60,10 +59,10 @@ class SCCUploader:
 
             if response.status_code == 200:
                 self._log.info("Successfully Uploaded details to SCC for %s",
-                               hv.backend)
+                               backend)
             else:
                 self._log.error("Failed to Upload details to SCC for %s",
-                                hv.backend)
+                                backend)
                 if response.status_code == 429:
                     # TODO(mbelur): retry again
                     pass

--- a/src/scc_hypervisor_collector/api/util.py
+++ b/src/scc_hypervisor_collector/api/util.py
@@ -1,0 +1,42 @@
+"""SCC Hypervisor Collector API utility code."""
+
+import getpass
+import stat
+from pathlib import Path
+from typing import Type
+
+from .exceptions import (
+    CollectorException,
+    FilePermissionsError,
+)
+
+
+def check_permissions(
+    path: Path,
+    fail_exc: Type[CollectorException] = FilePermissionsError
+) -> None:
+    """Check if path has the required permissions.
+
+    If issues are found the exception specified by fail_exc will be raised.
+    """
+    # collect required details
+    current_user = getpass.getuser()
+    stats = path.stat()
+    mode = stats.st_mode
+
+    # check the path owner
+    if path.owner() != current_user:
+        msg = f"{path} not owned by the user {current_user}"
+        raise fail_exc(msg)
+
+    # verify directory permissions
+    if path.is_dir() and stat.S_IMODE(mode) != 0o700:
+        msg = f"User { current_user } should have full access to " \
+              f"{path} but group and others should have no access."
+        raise fail_exc(msg)
+
+    # verify file permissions
+    if path.is_file() and stat.S_IMODE(mode) != 0o600:
+        msg = f"User {current_user} should have read/write access " \
+              f"to {path} but group and others should have no access."
+        raise fail_exc(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,11 @@ import pathlib
 import pytest
 import os
 
-from scc_hypervisor_collector.api import ConfigManager, HypervisorCollector
+from scc_hypervisor_collector.api import (
+    ConfigManager,
+    CollectionResults,
+    HypervisorCollector,
+)
 from scc_hypervisor_collector import cli
 
 
@@ -44,6 +48,13 @@ def hypervisor_collector(backendid, config_manager):
 def scc_hypervisor_collector_cli(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     return cli
+
+@pytest.fixture
+def collected_results(request):
+    marker = request.node.get_closest_marker("config")
+    colresults = CollectionResults()
+    colresults.load(pathlib.Path(marker.args[0]))
+    return colresults
 
 def pytest_configure(config):
     config.addinivalue_line(

--- a/tests/unit/data/collected/libvirt/collector.results
+++ b/tests/unit/data/collected/libvirt/collector.results
@@ -1,0 +1,27 @@
+- backend: libvirt1
+  details:
+    virtualization_hosts:
+    - group_name: libvirt1
+      identifier: 2c0638ba-1429-4851-96cf-2e9fd1ce4c8b
+      properties:
+        arch: x86_64
+        cores: 8
+        name: libvirt1.example.com
+        ram_mb: 64235
+        sockets: 2
+        threads: 2
+        type: QEMU
+      systems:
+      - properties:
+          vmState: running
+          vm_name: test-sle12
+        uuid: 01d10a82-5a4e-43cd-9bfb-d9fb5918a3be
+      - properties:
+          vmState: running
+          vm_name: test-sle15
+        uuid: 0324bef3-24e0-4151-9e63-6c5867de6b95
+      - properties:
+          vmState: running
+          vm_name: test-leap154
+        uuid: d556b8dd-832b-4670-83c8-78431b70bfea
+  valid: true

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -218,7 +218,7 @@ class TestConfigManager:
     def test_config_file_incorrect_permissions(self):
         filename='tests/unit/data/config/perm/perm.yml'
         os.chmod(filename, 0o777)
-        with pytest.raises(exceptions.ConfigManagerError,
+        with pytest.raises(exceptions.ConfigFilePermissionsError,
                            match=r".* should have read/write access .* but group and others should have no access."):
             config_manager = ConfigManager(config_file=filename)
             config_manager.config_data
@@ -226,7 +226,7 @@ class TestConfigManager:
     def test_config_dir_incorrect_permissions(self):
         dirname='tests/unit/data/config/perm'
         os.chmod(dirname, 0o777)
-        with pytest.raises(exceptions.ConfigManagerError,
+        with pytest.raises(exceptions.ConfigFilePermissionsError,
                            match=r".* should have full access to .* but group and others should have no access."):
             config_manager = ConfigManager(config_dir=dirname)
             config_manager.config_data

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -1,0 +1,167 @@
+from collections import namedtuple
+import mock
+import pytest
+from requests.exceptions import RequestException
+
+from scc_hypervisor_collector.api import (
+    SccCredsConfig,
+    SCCUploader
+)
+
+FakeResponse = namedtuple('FakeResponse', 'status_code')
+required_uploader_headers = [
+    'X-Gatherer-Version',
+    'X-Scc-Hypervisor-Collector-Version',
+    'Content-Type',
+]
+
+class TestUploader:
+
+    def test_uploader_init(self):
+        scc_url1 = 'https://scc1.example.com'
+        scc_url2 = 'https://scc2.example.com'
+        scc_token = 'dummy_token'
+
+        scc_creds = SccCredsConfig(dict(password='someuser',
+                                        username='somepass',
+                                        url=scc_url1))
+        assert scc_creds.url == scc_url1
+
+        with mock.patch('requests.auth.HTTPBasicAuth',
+                        return_value=scc_token) as http_basic_auth:
+            uploader = SCCUploader(scc_creds,
+                                   scc_base_url=scc_url2)
+            http_basic_auth.assert_called_with(scc_creds.username,
+                                               scc_creds.password)
+            assert uploader.scc_base_url != scc_url1
+            assert uploader.scc_base_url == scc_url2
+            assert uploader.auth == scc_token
+            assert all(h in uploader.headers
+                       for h in required_uploader_headers)
+
+
+    def test_uploader_check_creds(self):
+        scc_url = 'https://scc.example.com'
+        scc_token = 'dummy_token'
+        scc_test_path = '/test'
+        scc_payload = 'compressed_data'
+        scc_creds = SccCredsConfig(dict(password='someuser',
+                                        username='somepass',
+                                        url=scc_url))
+        uploader = SCCUploader(scc_creds)
+
+        with mock.patch('requests.get', return_value=FakeResponse(200)
+                       ) as requests_get:
+            response = uploader.check_creds(path=scc_test_path)
+            requests_get.assert_called_with(
+                scc_url + scc_test_path,
+                auth=uploader.auth,
+                headers=uploader.headers,
+                allow_redirects=False
+            )
+
+
+    @pytest.mark.config('tests/unit/data/collected/libvirt/collector.results')
+    def test_upload_hypervisor_details_to_scc_success(self, collected_results):
+        scc_url = 'https://scc.example.com'
+        scc_test_path = '/test'
+        scc_payload = 'compressed_data'
+
+        scc_creds = SccCredsConfig(dict(password='someuser',
+                                        username='somepass',
+                                        url=scc_url))
+
+        uploader = SCCUploader(scc_creds)
+
+        with mock.patch('requests.put', return_value=FakeResponse(200)
+                       ) as requests_put:
+            for results in collected_results.results:
+                with mock.patch('gzip.compress', return_value=scc_payload):
+                    uploader.upload(details=results['details'],
+                                    backend=results['backend'],
+                                    path=scc_test_path)
+                    requests_put.assert_called_with(
+                        scc_url + scc_test_path,
+                        auth=uploader.auth,
+                        headers=uploader.headers,
+                        data=scc_payload,
+                        allow_redirects=False
+                    )
+
+
+    @pytest.mark.config('tests/unit/data/collected/libvirt/collector.results')
+    def test_upload_hypervisor_details_to_scc_failed(self, collected_results):
+        scc_url = 'https://scc.example.com'
+        scc_test_path = '/test'
+        scc_payload = 'compressed_data'
+
+        scc_creds = SccCredsConfig(dict(password='someuser',
+                                        username='somepass',
+                                        url=scc_url))
+
+        uploader = SCCUploader(scc_creds)
+
+        with mock.patch('requests.put', return_value=FakeResponse(500)
+                       ) as requests_put:
+            for results in collected_results.results:
+                with mock.patch('gzip.compress', return_value=scc_payload):
+                    uploader.upload(details=results['details'],
+                                    backend=results['backend'],
+                                    path=scc_test_path)
+                    requests_put.assert_called_with(
+                        scc_url + scc_test_path,
+                        auth=uploader.auth,
+                        headers=uploader.headers,
+                        data=scc_payload,
+                        allow_redirects=False
+                    )
+
+
+    @pytest.mark.config('tests/unit/data/collected/libvirt/collector.results')
+    def test_upload_hypervisor_details_to_scc_retry(self, collected_results):
+        scc_url = 'https://scc.example.com'
+        scc_test_path = '/test'
+        scc_payload = 'compressed_data'
+
+        scc_creds = SccCredsConfig(dict(password='someuser',
+                                        username='somepass',
+                                        url=scc_url))
+
+        uploader = SCCUploader(scc_creds)
+
+        with mock.patch('requests.put', return_value=FakeResponse(429)
+                       ) as requests_put:
+            for results in collected_results.results:
+                with mock.patch('gzip.compress', return_value=scc_payload):
+                    uploader.upload(details=results['details'],
+                                    backend=results['backend'],
+                                    path=scc_test_path)
+                    requests_put.assert_called_with(
+                        scc_url + scc_test_path,
+                        auth=uploader.auth,
+                        headers=uploader.headers,
+                        data=scc_payload,
+                        allow_redirects=False
+                    )
+
+
+    @pytest.mark.config('tests/unit/data/collected/libvirt/collector.results')
+    def test_upload_hypervisor_details_put_exception(self, collected_results):
+        scc_url = 'https://scc.example.com'
+        scc_test_path = '/test'
+        scc_payload = 'compressed_data'
+
+        scc_creds = SccCredsConfig(dict(password='someuser',
+                                        username='somepass',
+                                        url=scc_url))
+
+        uploader = SCCUploader(scc_creds)
+
+        with mock.patch('requests.put', return_value=FakeResponse(200)
+                       ) as requests_put:
+            for results in collected_results.results:
+                with mock.patch('gzip.compress', return_value=scc_payload):
+                    requests_put.side_effect = RequestException("Failed")
+                    uploader.upload(details=results['details'],
+                                    backend=results['backend'],
+                                    path=scc_test_path)


### PR DESCRIPTION
Add support for a collect and save to file mode, with a corresponding upload from previously saved file mode.

To collect the hypervisor details and save them to a file, the user can leverage the new '--output' option to specify an output file in which the collected details for all backends will be saved, in YAML format.

To upload (previously collected) data from a file the new '--input' option can be used to specify the YAML file containing the saved collection details to the SCC.

Note that the uploading system will not be required to specify the backends associated with the details being uploaded as part of the scc-hypervisor-collection config settings; only the SCC credentials config will be required on the uploading system.

However the system doing the collection still needs SCC creds to be specified, but these will not be used, and potentiall can be dummy values.

Summary of Code changes:

* Modified the HypervisorCollector.details to be a separate class (HypervisorDetails) hosting the collected details in the required payload format for uploading to the SCC.
* Added a new CollectionResults class to host the details that have been collected by the various hypervisors managed by the scheduler, that can be initialised from a provided scheduler, or can save and load details to or from a YAML file.
* Modified the CLI '--upload' option handling to leverage the new CollectionScheduler.results property (CollectionResults) as the' source for data to be uploaded.
* Added CLI support for the '--output' option which saves the new CollectionScheduler.results property's contents to a file, and skips the upload step.
* Added CLI support for the '--input' option which loads the YAML file content as the collection results which are used to upload the data to the SCC, skipping the scheduler driven collection of data from configured backends altogether.
* Split the permissions checking static method out of ConfigManager into the api.util subpackage, so that it could be leveraged by the CollectionResults load & save methods.
* Misc changes to code to address pylint complaints caused by the addition of code to existing complex functions/methods that lead to them exceeding complexity thresholds.
* Added unit testing for the new features implemented in this patch as well as some additional tests for the api.uploader subpackage to increase our coverage back over 90%.