### PR TITLE
Miscellaneous cleanup items.

### DIFF
--- a/.venv-requirements.txt
+++ b/.venv-requirements.txt
@@ -1,4 +1,3 @@
-black
 bumpversion
 tox
 tox-pyenv

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This project uses the following tools as part of the development process:
 * `bumpversion` to manage version updates.
 * `pandoc` to generate man pages from Markdown inputs.
   See [man pages README](doc/man/README.md)
-* optionally `black` to manage code style/layout.
 
 ## Helper scripts
 In the [bin directory](bin/) a number of helper scripts are provided:
@@ -36,7 +35,6 @@ In the [bin directory](bin/) a number of helper scripts are provided:
 * `tox` - a `command-wrapper` symlink that can be used to run `tox`.
 * `bumpversion` and `bump2version` - `command-wrapper` symlinks that
    can be used to run the `bumpversion` and `bump2version` commands.
-* `black` - a `command-wrapper` symlink that can be used to run `black`.
 * `tox_dev-wrapper` - a generic command wrapper that can be symlinked
   to a command name, and when invoked via that symlink will look for
   the named command in the `tox` created `.tox/dev` venv, or failing
@@ -62,9 +60,6 @@ The [tox.ini] file is configured to run the following tests:
   skipped.
 
 Additional tests are also available to be run:
-* `py<version>-nocov` - run `pytest` without coverage checking against
-  installed versions of the code for various potential Python versions;
-  missing Python versions will be skipped.
 * `dev` - installs the package's dependencies and then installs the package
   itself in developer mode, allowing you to run the code locally for adhoc
   testing purposes via `bin/scc-hypervisor-collector`.
@@ -84,10 +79,12 @@ tox driven testing. You will still need to install the relevant versions of
 the Python interpreter using `pyenv install <version>` for them to actually be
 available for use by `tox`.
 
-# Packaging Support
+# Package and Container Image Building
 
 An [RPM spec file](scc-hypervisor-collector.spec) is provided which is ready
-to be used by the openSUSE Build Service (OBS).
+to be used by the openSUSE Build Service (OBS) to build SLE 15 SP2/3/4 based
+RPMs. The packaging process leverages the service and timer scripts provided
+under the [systemd directory](systemd).
 
 Additionally a [Dockerfile](container/Dockerfile) (suitable for building a
 container image in OBS) and an accompanying [entrypoint script](container/entrypoint.bash)
@@ -102,7 +99,7 @@ ensuring the configuration settings and runtime environment for the command
 are correctly setup.
 
 See [Container Deployment](doc/Container_Deployment.md) for details on how to
-run the command using a container image built using the [Dockerfile](container/Dockerfile)
+run the command using a container image built using the provided [Dockerfile](container/Dockerfile)
 and the [Open Build Service](https://build.opensuse.org).
 
 # The scc-hypervisor-collector design

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,17 +3,18 @@ current_version = 0.0.5
 commit = True
 tag = True
 
+[bumpversion:file:src/scc_hypervisor_collector/__init__.py]
+
 [metadata]
 license_file = LICENSE
 version = attr: scc_hypervisor_collector.__version__
-
-[bumpversion:file:src/scc_hypervisor_collector/__init__.py]
 
 [check-manifest]
 ignore = 
 	tox.ini
 	*.spec
 	*requirements.txt
+	.obs/**
 	.venv/**
 	.vscode/**
 	bin/**
@@ -22,7 +23,6 @@ ignore =
 	examples/**
 	systemd/**
 	tests/**
-	.obs/**
 
 [tool:pytest]
 norecursedirs = 
@@ -30,6 +30,7 @@ norecursedirs =
 	.vscode
 	.eggs
 	.git
+	.obs
 	.tox
 	bin
 	container
@@ -41,6 +42,7 @@ testpaths = tests
 exclude = 
 	.eggs
 	.git
+	.obs
 	.tox
 	.venv
 	.vscode

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ test_requirements = [
 
 # Recommened developer tools
 dev_requirements = [
-    "black",
     "bumpversion",
     "tox",
 ]


### PR DESCRIPTION
Remove references to the black code formatter as we never really leveraged it, and enabling use of it now would likely result in many formatting changes.

Remove references to the py<version>-nocov tox tests (which were removed previously from tox.ini) from the README.md.

Other minor tweaks to the README.md text related to packaging and container image building.

Minor tweaks to setup.cfg to add the .obs directory to all relevant exclusion lists, and move all of the bumversion settings together.