### PR TITLE
Packaging tweaks

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -2,13 +2,14 @@
 # NOTE: First tag used to derive build name if not specified
 #!BuildTag: suse/scc-hypervisor-collector/sle%OS_VERSION_ID_SP%:%PKG_VERSION%.%TAG_OFFSET% suse/scc-hypervisor-collector/sle%OS_VERSION_ID_SP%:%PKG_VERSION%.%TAG_OFFSET%.%RELEASE% suse/scc-hypervisor-collector/sle%OS_VERSION_ID_SP%:%PKG_VERSION% suse/scc-hypervisor-collector/sle%OS_VERSION_ID_SP%:latest
 
+# Ensure this base container image version matches the images repository version
 FROM suse/sle15:15.3
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.example
 PREFIXEDLABEL org.opencontainers.image.title="SCC Hypervisor Collector SLE %OS_VERSION_NO_DASH% container"
 PREFIXEDLABEL org.opencontainers.image.description="This contains scc-hypervisor-collector %PKG_VERSION%"
-PREFIXEDLABEL org.opensuse.reference="registry.suse.com/suse/scc-hypervisor-collector-sle15sp3:%PKG_VERSION%.%RELEASE%"
+PREFIXEDLABEL org.opensuse.reference="registry.suse.com/suse/scc-hypervisor-collector:%PKG_VERSION%.%RELEASE%"
 PREFIXEDLABEL org.openbuildservice.disturl="%DISTURL%"
 PREFIXEDLABEL org.opencontainers.image.created="%BUILDTIME%"
 

--- a/scc-hypervisor-collector.spec
+++ b/scc-hypervisor-collector.spec
@@ -44,7 +44,7 @@ BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
 BuildRequires:  virtual-host-gatherer-Libvirt
 BuildRequires:  virtual-host-gatherer-VMware
-Requires:       %{name}-common
+Requires:       %{name}-common-%{version}
 BuildArch:      noarch
 %if 0%{?suse_version} < 1530
 BuildRequires:  %{python_module setuptools}


### PR DESCRIPTION
Ensure that the scc-hypervisor-collector package depends on the matching version of the scc-hypervisor-collector-common package so that if the user runs 'zypper in scc-hypervisor-collector' then both the base and -common packages are updated rather than just the base package.

Minor tweak to the prefix label settings in the Dockerfile.