### PR TITLE
Disable bumpversion tagging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.0.5
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:src/scc_hypervisor_collector/__init__.py]
 


### PR DESCRIPTION
Since the main branch is now a potected branch, requiring a PR to land changes, this means that the bumpversion created tag will not match the merged PR change; the tag needs to be created after the PR has merged.