### PR TITLE
Package and container build service integration tweaks

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -1,32 +1,27 @@
 Open Build Service Container Build
 ==================================
 
-The `_service.example` can be used to setup a container build project that
-will automatically retrieve the scc-hypervisor-collector source tarball
-from GitHub and extract the Dockerfile and extrypoint.bash scripts. Run
-`osc service manualrun` to set things up, and then `osc commit` to push
-the container package build definition up to OBS so that it will start
-attempting to build it.
+The `_service.example` can be used to setup a container build project
+that will automatically retrieve the scc-hypervisor-collector source
+tarball from GitHub and extract the Dockerfile and extrypoint.bash
+scripts.
 
-You will also need to ensure that you have configured the OBS project in
-which the container package is being built with 'Project Config' settings
-that ensure it is building the container using the `docker` build type,
-like this:
+The buildtime service definitions will ensure that the appropriate 
+values are substituted for the placeholders during the package build.
 
-```
-%if "%_repository" == "containers"
-Type: docker
-Repotype: none
-Patterntype: none
-%endif
-```
+Run `osc service manualrun` to setup the container build, then run
+`osc addremove` to include the modified files in the changeset and
+finally run `osc commit` to push the container build definition up
+to OBS so that it will start attempting to build it, which will fail
+until the required configuration steps, outlined below, are completed.
 
 Additionally you will need to define a `containers` repository that
 points to the project in which the `scc-hypervisor-collector` is being
 built, and then to the project associated with the SLE version that the
-container will be based upon. For example the container build project
-'Meta', when building a SLE 15 SP3 based container, could look something
-like:
+container will be based upon.
+
+For example the container build project 'Meta', if building a SLE 15 SP3
+based container, should look something like:
 
 ```
 <project name="home:someuser:systemsmanagement:containers">
@@ -45,3 +40,23 @@ like:
   </repository>
 </project>
 ```
+
+Finally, you will need to ensure that you have configured the OBS project in
+which the container package is being built with 'Project Config' settings
+that ensure it is building the container using the `docker` build type,
+like this:
+
+```
+%if "%_repository" == "containers"
+Type: docker
+Repotype: none
+Patterntype: none
+
+# Required to resolve a dependency choice issue.
+Prefer: dbus-1
+%endif
+```
+
+NOTE: If you named your containers repository something other than `containers`,
+e.g `SLE_15_SP3_containers`, then make sure that the repository name in your 
+'Project Config' settings matches, otherwise the build will fail.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,33 @@
+Open Build Service Package Build
+================================
+
+The `_service.example` can be used to setup a *scc-hypervisor-collector*
+package build that will automatically retrieve the *scc-hypervisor-collector*
+source tarball from GitHub and extract the RPM spec file and systemd timer
+and service unit files.
+
+The spec file version value will also be updated to match the version just
+pulled from Github.
+
+If it doesn't already exist, touch the *scc-hypervisor-collector.changes*
+file to ensure that change log entries are automatically generated for
+upstream changes as part of the service run.
+
+Run `osc service manualrun` to set things up, and then `osc addremove`
+followed by `osc commit` to push the package build definition up to OBS
+so that it will start attempting to build the package, which may fail if
+the required dependencies are not available.
+
+When updating an existing package you will need to manually delete the
+existing source tarball, e.g. run `rm scc-hypervisor-collector*.tar.xz`,
+before running the `osc service manualrun` to ensure that only the latest
+tarball is stored in the OBS package definition.
+
+The *scc-hypervisor-collector* package depends on having a viable version
+of the *virtual-host-gatherer* package available to install; at the time
+of writing this documenmt the existing OBS systemsmanagement:Uyuni:Master
+package is based upon the 1.0.23 version tag, which doesn't include the
+changes that were landed in PRs #27 and #29. Please ensure that you are
+building a viable version of the *virtual-host-gatherer* package beside
+the *scc-hypervisor-collector* package, and that it is enabled for use
+when building other packages.

--- a/packaging/_service.example
+++ b/packaging/_service.example
@@ -18,21 +18,11 @@
   </service>
   <service name="extract_file" mode="manual">
     <param name="archive">scc-hypervisor-collector*.tar.xz</param>
-    <param name="files">scc-hypervisor-collector-*/container/Dockerfile</param>
-    <param name="files">scc-hypervisor-collector-*/container/entrypoint.bash</param>
+    <param name="files">scc-hypervisor-collector-*/scc-hypervisor-collector.spec</param>
+    <param name="files">scc-hypervisor-collector-*/systemd/scc-hypervisor-collector.service</param>
+    <param name="files">scc-hypervisor-collector-*/systemd/scc-hypervisor-collector.timer</param>
   </service>
-  <service name="kiwi_metainfo_helper" mode="buildtime"/>
-  <service name="replace_using_package_version" mode="buildtime">
-    <param name="file">Dockerfile</param>
-    <param name="regex">%PKG_VERSION%</param>
-    <param name="package">scc-hypervisor-collector-common</param>
-    <param name="parse-version">patch_update</param>
+  <service name="set_version" mode="manual">
+    <param name="file">scc-hypervisor-collector.spec</param>
   </service>
-  <service name="replace_using_package_version" mode="buildtime">
-    <param name="file">Dockerfile</param>
-    <param name="regex">%TAG_OFFSET%</param>
-    <param name="package">scc-hypervisor-collector-common</param>
-    <param name="parse-version">offset</param>
-  </service>
-  <service mode="buildtime" name="docker_label_helper"/>
 </services>

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ ignore =
 	container/**
 	doc/**
 	examples/**
+	packaging/**
 	systemd/**
 	tests/**
 
@@ -35,6 +36,7 @@ norecursedirs =
 	bin
 	container
 	doc
+	packaging
 	systemd
 testpaths = tests
 
@@ -49,6 +51,7 @@ exclude =
 	bin
 	container
 	doc
+	packaging
 	systemd
 	tests
 


### PR DESCRIPTION
Added a packaging/README.md file outlining how to define a package build for the scc-hypervisor-collector in OBS. Also provided a reference example of the _serice file that can be used to maintain the package sources via 'osc service manualrun'.

Updated the container README.md and _service.example based upon recent experience setting up a container build in OBS.