### PR TITLE
Add maintenance workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,57 @@ Additionally a [Dockerfile](container/Dockerfile) (suitable for building a
 container image in OBS) and an accompanying [entrypoint script](container/entrypoint.bash)
 are provided in the [container directory](container).
 
+## Version Management
+
+The `bin/bumpversion` command should be used to update the version of the
+`scc-hypervisor-collector` tool, following semantic versioning practices
+of `%MAJOR%.%MINOR%.%PATCH%`.
+
+If the version bump is due to merging bug fixes and other minor changes,
+then `patch` should be specified as the argument when calling `bumpversion`
+which will cause the last element of the version to be incremented by one.
+
+If the version bump is due to landing a new feature which enhances the
+`scc-hypervisor-collector` in a backwards compatible way, then `minor` should
+be specified as the the argument to `bumpversion` which will increments the
+middle element of the version and resets the last element to `0`.
+
+If the version bump is due to landing new features or other functionality
+changes that are not backwards compatible, then `major` should be passed as
+the argument when calling `bumpversion` which will increment the first element
+of the version and resets middle and last elements to `0`.
+
+After running the `bumpversion` command the resulting change should be proposed
+as a new PR, to be reviewed, approved, and eventually merged.
+
+## Version Tagging
+
+Whenever the version is updated, once the PR that contains the version change
+has merged, a matching new version tag in the format of `v%VERSION%` should be
+created and pushed to the repository using commands similar to the following,
+where `%old_version%` and `%new_version%` are, respectively, the previous and
+updated versions:
+
+```
+% git tag -m "Bump version: %old_version% → %new_version%" "v%new_version%" origin/main
+% git push --tags origin
+```
+
+## Package and Container Versioning
+
+The current OBS based package build workflow will automatically set the RPM
+package verison to `%VERSION%~git%TAG_OFFSET%.%GIT_SHA%`, so even merged PR
+will result in an updated version. And the same version info will be used to
+generate the version tags for the container image that will be rebuilt in OBS
+whenever the main package gets updated.
+
+See [OBS Maintenance Workflow](doc/OBS_Maintance_Workflow.md) for more details
+on how to ensure that the RPM package is rebuilt to pick up the latest changes
+to the `scc-hypervisor-collector` sources, setup scripts, spec file and systemd
+unit files, as well as how to ensure the container build picks up the latest
+changes to the [Dockerfile](container/Dockerfile) and [entrypoint.bash](container/entrypoint.bash)
+scripts.
+
 # Running the scc-hypervisor-collector
 
 See the [man pages](doc/man) for details about running the command locally.

--- a/doc/OBS_Maintenance_Workflow.md
+++ b/doc/OBS_Maintenance_Workflow.md
@@ -1,0 +1,92 @@
+OBS Maintenance Workflow
+========================
+
+# `scc-hypervisor-collector` package
+
+The `scc-hypervisor-collector` package is built in the Open Build Service
+(OBS) under the [systemsmanagement:SCC](https://build.opensuse.org/project/show/systemsmanagement:SCC)
+project.
+
+While an `_service` file is used to manage the retrieval of the sources,
+and the subsequent extraction of the spec file and systemd unit scripts,
+and update the changes file with PRs landed since last recent tag and
+last update, these actions currently need to be triggered manually.
+
+The recommended command sequence to use is as follows, replacing the
+placeholder OBS user account (`obsuser`) with your OBS user name:
+
+* Branch checkout the systemsmanagement:SCC/scc-hypervisor-collector package
+
+```
+% osc bco systemsmanagement:SCC scc-hypervisor-collector
+```
+
+* Switch to the branched checkout directory and update the sources
+  and packages changes file, extract the spec file and system unit
+  files:
+
+```
+% cd home:obsuser:branches:systemsmanagement:SCC/scc-hypervisor-collector
+% rm *.tar.xz  # remove the existing versioned sources tarball
+% osc service manualrun  # downloads new sources tarball, extracts file
+% osc addremove  # Adds new files, removes deleted ones
+% osc commit
+```
+
+* Verify that the updated package builds, resolving any issues encountered.
+
+* Submit the working package build to the main project:
+
+```
+% osc submitrequest
+```
+
+* Wait for a `systemsmanagement:SCC` project maintainer to review your
+  request and hopefully accept it.
+
+
+# `scc-hypervisor-collector` container
+
+The `scc-hypervisor-collector` container image is built in the Open Build
+Service under the [systemsmanagement:SCC:containers](https://build.opensuse.org/project/show/systemsmanagement:SCC:containers)
+project.
+
+Similarly to the `scc-hypervisor-collector` package, an `_service`
+file is used to manage to retrieval of the sources, and the subsequent
+extraction of the [Dockerfile](container/Dockerfile) and the
+[extrypoint.bash](container/extrypoint.bash) scripts, though again
+these actions currently need to be triggered manually.
+
+The recommended command sequence to use is as follows, replacing the
+placeholder OBS user account (`obsuser`) with your OBS user name,
+and assuming you are updating the SLE 15 SP3 based container:
+
+* Branch checkout the systemsmanagement:SCC:containers/scc-hypervisor-collector-sle15sp3
+  container package
+
+```
+% osc bco systemsmanagement:SCC:containers scc-hypervisor-collector-sle15sp3
+```
+
+* Switch to the branched checkout directory and update the sources,
+  and extracting the `Dockerfile` and `extrypoint.bash` scripts:
+
+```
+% cd home:obsuser:branches:systemsmanagement:SCC:containers/scc-hypervisor-collector-sle15sp3
+% rm *.tar.xz  # remove the existing versioned sources tarball
+% osc service manualrun  # downloads new sources tarball, extracts file
+% osc addremove  # Adds new files, removes deleted ones
+% osc commit
+```
+
+* Verify that the updated package builds, resolving any issues encountered.
+
+* Submit the working package build to the main project:
+
+```
+% osc submitrequest
+```
+
+* Wait for a `systemsmanagement:SCC:containers` project maintainer to review
+  your request and hopefully accept it.
+

--- a/scc-hypervisor-collector.spec
+++ b/scc-hypervisor-collector.spec
@@ -25,7 +25,7 @@
 %{?!python_install:%define python_install %{expand:%py3_install}}
 
 Name:           scc-hypervisor-collector
-Version:        0.0.2~git18.e27f17d
+Version:        0.0.5
 Release:        0
 Summary:        Regularly collect and upload hypervisor details to SUSE Customer Care
 License:        Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ commit = True
 tag = False
 
 [bumpversion:file:src/scc_hypervisor_collector/__init__.py]
+[bumpversion:file:scc_hypervisor_collector.spec]
 
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
Add doc/OBS_Maintenance_Workflow.md which outlines the steps needed to maintain the package and container builds in OBS.

Updated the README.md with details about the versioning scheme and version management workflow.

Configured the scc-hypervisor-collector.spec file to have a version that is managed by the version management workflow; the version will always be rewritten by the 'osc service manualrun` per the associated _service file definitions, so this change is purely cosmetic.