### PR TITLE
Documentation tweaks and improved examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,19 +166,46 @@ be user access only (0700) for the user that will run the tool.
 The tool cannot be run with root privileges. 
 
 ## `ConfigManager` - Configuration Management
-TBD
+The `ConfigManager` class is implemented in
+[api/config_manger.py](src/scc-hypervisor-collector/api/config_manager.py)
+and leverages the various configuration management classes found in
+[api/configuration.py](src/scc-hypervisor-collector/api/configuration.py)
+to load and validate the `scc-hypervisor-collector` configuration data.
 
 ## `HypervisorCollector` - Collector for Hypervisor details
-TBD
+The `HypervisorCollector` class is implemented in
+[api/hypervisor_collector.py](src/scc-hypervisor-collector/api/hypervisor_collector.py)
+and leverages the
+[Virtual Host Gatherer](https://github.com/uyuni-project/virtual-host-gatherer/)
+as a Python3 library to collect relevant details from the conigfured hypervisor
+solution.
+
+## `CollectionScheduler` - Schedules Hypervisor collection and SCC uploads
+The `CollectionScheduler` class is implemented in
+[api/scheduler.py](src/scc-hypervisor-collector/api/scheduler.py) and is
+responsible for scheduling the retrieval of details from the configured
+hypervisor solutions.
 
 ## `SCCUploader` - Uploads collected Hypervisor details to SCC
-TBD
-
-## `CollectionManager` - Schedules Hypervisor collection and SCC uploads
-TBD
+The `SCCUploader` class is implemented in
+[api/uploader.py](src/scc-hypervisor-collector/api/uploader.py) and is used
+to upload collected hypervisor details to the SUSE Customer Center via the
+[organizations/virtualization_hosts](https://scc.suse.com/connect/v4/documentation#/organizations/put_organizations_virtualization_hosts) API.
 
 ## `cli` - CLI wrapper that drives the other APIs
-TBD
+The `scc_hypervisor_collector.cli:main` routine is implemented in
+[cli/__init__.py](src/scc-hypervisor-collector/cli/__init__.py)
+and provides the command line interface for `scc-hypervisor-collector`.
 
-## Configuration Schema
-TBD
+# Configuration Examples
+See the [examples directory](examples) for examples of configuration
+settings:
+
+* [all_in_one](examples/all_in_one) shows an example of specifying all
+  of the settings in a single configuration file.
+* [creds_and_backends](examples/creds_and_backends) shows an example of
+  specifying the credentials settings in one configuration file and the
+  backends settings in another configuration file.
+* [multiple_files](examples/multiple_files) shows an example of specifying
+  the credentials settings in one configuration file and the various
+  backends settings in backend type specific configuration files.

--- a/doc/Container_Deployment.md
+++ b/doc/Container_Deployment.md
@@ -54,10 +54,11 @@ SLE 15 SP3 based container build.
 
 # Container based workflow
 
-The [Dockerfile](../container/Dockerfile) is intended to be run against
-a directory that has been setup appropriately to act as the home directory
-of a user that will run the `scc-hypervisor-collector` command, as defined
-above.
+The image built by the [Dockerfile](../container/Dockerfile), leveraging
+the provided [entrypoint.bash](../container/entrypoint.bash), is intended
+to be run against a directory that has been setup appropriately to act as
+the home directory of a user that will run the `scc-hypervisor-collector`
+command, as defined above.
 
 This directory should be bind mounted to the `/var/lib/scchvc` directory
 when running the tool via a container.

--- a/doc/OBS_Maintenance_Workflow.md
+++ b/doc/OBS_Maintenance_Workflow.md
@@ -8,9 +8,11 @@ The `scc-hypervisor-collector` package is built in the Open Build Service
 project.
 
 While an `_service` file is used to manage the retrieval of the sources,
-and the subsequent extraction of the spec file and systemd unit scripts,
-and update the changes file with PRs landed since last recent tag and
-last update, these actions currently need to be triggered manually.
+and the subsequent extraction of the [spec file](../scc-hypervisor-collector.spec)
+and [systemd unit scripts](../systemd), and update the changes file with
+details about the PRs landed since between the most recent tag and last
+update, as well as setting the spec file version appropriately, these
+actions currently need to be triggered manually.
 
 The recommended command sequence to use is as follows, replacing the
 placeholder OBS user account (`obsuser`) with your OBS user name:
@@ -53,8 +55,8 @@ project.
 
 Similarly to the `scc-hypervisor-collector` package, an `_service`
 file is used to manage to retrieval of the sources, and the subsequent
-extraction of the [Dockerfile](container/Dockerfile) and the
-[extrypoint.bash](container/extrypoint.bash) scripts, though again
+extraction of the [Dockerfile](../container/Dockerfile) and the
+[extrypoint.bash](../container/extrypoint.bash) scripts, though again
 these actions currently need to be triggered manually.
 
 The recommended command sequence to use is as follows, replacing the

--- a/examples/all_in_one/shc_cfg.yaml
+++ b/examples/all_in_one/shc_cfg.yaml
@@ -17,7 +17,7 @@ backends:
     username: "VMware_Account_Username"
     password: "VMware_Account_Password"
 
-  # A Libvirt Hypervisor node
+  # A Libvirt hypervisor example
   - id: "Libvirt1"
     module: "Libvirt"
     uri: "qemu+ssh:///system"

--- a/examples/creds_and_backends/backends.yml
+++ b/examples/creds_and_backends/backends.yml
@@ -1,0 +1,19 @@
+---
+
+# Hypervisor Backends
+backends:
+
+  # A Libvirt hypervisor example
+  - id: "Libvirt1"
+    module: "Libvirt"
+    uri: "qemu+ssh:///system"
+    sasl_username: "Libvirt_Account_Username"
+    sasl_password: "Libvirt_Account_Password"
+
+  # A vCenter example
+  - id: "VCenter1"
+    module: "VMware"
+    hostname: "vcenter1.example.com"
+    port: 443
+    username: "VMware_Account_Username"
+    password: "VMware_Account_Password"

--- a/examples/creds_and_backends/credentials.yml
+++ b/examples/creds_and_backends/credentials.yml
@@ -1,0 +1,7 @@
+---
+
+# Credentials
+credentials:
+  scc:
+    username: "SCC_Account_Username"
+    password: "SCC_Account_Password"

--- a/examples/multiple_files/credentials.yml
+++ b/examples/multiple_files/credentials.yml
@@ -1,0 +1,7 @@
+---
+
+# Credentials
+credentials:
+  scc:
+    username: "SCC_Account_Username"
+    password: "SCC_Account_Password"

--- a/examples/multiple_files/libvirt.yml
+++ b/examples/multiple_files/libvirt.yml
@@ -1,0 +1,11 @@
+---
+
+# Libvirt Hypervisor Backends
+backends:
+
+  # A Libvirt hypervisor example
+  - id: "Libvirt1"
+    module: "Libvirt"
+    uri: "qemu+ssh:///system"
+    sasl_username: "Libvirt_Account_Username"
+    sasl_password: "Libvirt_Account_Password"

--- a/examples/multiple_files/vcenter.yml
+++ b/examples/multiple_files/vcenter.yml
@@ -1,0 +1,12 @@
+---
+
+# VMWare vCenter Hypervisor Backends
+backends:
+
+  # A vCenter example
+  - id: "VCenter1"
+    module: "VMware"
+    hostname: "vcenter1.example.com"
+    port: 443
+    username: "VMware_Account_Username"
+    password: "VMware_Account_Password"

--- a/scc-hypervisor-collector.spec
+++ b/scc-hypervisor-collector.spec
@@ -98,7 +98,9 @@ export PYTHONPATH=%{buildroot}%{python_sitelib}
 # ensure example config permissions are correct
 chmod -R g-rwx,o-rwx examples
 %{buildroot}%{_bindir}/%{name} -h
-%{buildroot}%{_bindir}/%{name} --check --config examples/shc_cfg.yaml
+%{buildroot}%{_bindir}/%{name} --check --config examples/all_in_one/shc_cfg.yaml
+%{buildroot}%{_bindir}/%{name} --check --config-dir examples/creds_and_backends
+%{buildroot}%{_bindir}/%{name} --check --config_dir examples/multiple_files
 
 # run tests
 export NO_NETWORK_ACCESS=true

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,9 @@ commands =
     scc-hypervisor-collector --help
     scc-hypervisor-collector --version
     chmod -R g-rwx,o-rwx {toxinidir}/examples  # ensure correct permission
-    scc-hypervisor-collector --check --config {toxinidir}/examples/shc_cfg.yaml
+    scc-hypervisor-collector --check --config {toxinidir}/examples/all_in_one/shc_cfg.yaml
+    scc-hypervisor-collector --check --config-dir {toxinidir}/examples/creds_and_backends
+    scc-hypervisor-collector --check --config_dir {toxinidir}/examples/multiple_files
 
 [testenv:dev]
 description = Developer mode install


### PR DESCRIPTION
Flesh out the remaining imcomplete sections of the README.md.

Move the existing single config file example to examples/all_in_one and add additional examples showing how the configuration can be broken up into multiple config files in various ways.

Update spec and tox.ini files to reflect changes to the examples area.

Correct some typos in doc/Container_Deployment.md and doc/OBS_Maintenance_Workflow.md.