### PR TITLE
Fix main package's version specification for common package

### DIFF
--- a/scc-hypervisor-collector.spec
+++ b/scc-hypervisor-collector.spec
@@ -44,7 +44,7 @@ BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
 BuildRequires:  virtual-host-gatherer-Libvirt
 BuildRequires:  virtual-host-gatherer-VMware
-Requires:       %{name}-common-%{version}
+Requires:       %{name}-common == %{version}
 BuildArch:      noarch
 %if 0%{?suse_version} < 1530
 BuildRequires:  %{python_module setuptools}


### PR DESCRIPTION
My previous attempt at an exact version specification wasn't valid and lead to a broken dependency for the main package. Switching to using '==' for version specification works as intended.