### PR TITLE
Add gen_large_datasets and bulk_create utilities

### DIFF
--- a/bin/bulk_create
+++ b/bin/bulk_create
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+import gzip
+import json
+import os
+from pathlib import Path
+import requests
+import sys
+import yaml
+
+def last_seen_time():
+    #return datetime.datetime.now(datetime.timezone.utc).isoformat(sep=' ')
+    return f"{datetime.datetime.utcnow().isoformat(sep=' ')}000 +0000"
+
+
+class SccConfig:
+
+    def __init__(self, username, password, base_url, timeout = None):
+        if timeout is None:
+            timeout = 60
+
+        self.username = username
+        self.password = password
+        self.base_url = base_url
+        self.timeout = timeout
+
+
+class SccRequest:
+
+    def __init__(self, scc_config, success=200):
+        self._auth = None
+        self.scc_config = scc_config
+        self.default_headers = {
+            'Accept': 'application/vnd.scc.suse.com.v4+json',
+        }
+        self.success = success
+        self.response = None
+
+    @property
+    def username(self):
+        return self.scc_config.username
+
+    @property
+    def password(self):
+        return self.scc_config.password
+
+    @property
+    def base_url(self):
+        return self.scc_config.base_url
+
+    @property
+    def timeout(self):
+        return self.scc_config.timeout
+
+    @property
+    def auth(self):
+        if self._auth is None:
+            self._auth = requests.auth.HTTPBasicAuth(self.username, self.password)
+        return self._auth
+
+    def request_url(self, path):
+        return self.base_url.rstrip('/') + '/' + path.lstrip('/')
+
+    def request_headers(self, extra_headers=None):
+        if extra_headers is None:
+            extra_headers = {}
+
+        headers = {}
+        headers.update(self.default_headers)
+        headers.update(extra_headers)
+
+        return headers
+
+    def put(self, path, payload, extra_headers=None):
+        self.response = requests.put(
+            self.request_url(path),
+            auth=self.auth,
+            headers=self.request_headers(extra_headers),
+            #data=zipped_payload,
+            #data=json.dumps(upload_payload).encode('utf-8'),
+            json=payload,
+            allow_redirects=False,
+            timeout=self.timeout,
+        )
+        self.check_response()
+
+    def put_compressed(self, path, payload, extra_headers=None):
+        if extra_headers is None:
+            extra_headers = {}
+
+        extra_headers['Content-Type'] = 'application/json'
+        extra_headers['Content-Encoding'] = 'gzip'
+
+        compressed_payload = gzip.compress(json.dumps(payload).encode('utf-8'))
+
+        self.response = requests.put(
+            self.request_url(path),
+            auth=self.auth,
+            headers=self.request_headers(extra_headers),
+            data=compressed_payload,
+            allow_redirects=False,
+            timeout=self.timeout,
+        )
+        self.check_response()
+
+    def get(self, path, extra_headers=None):
+        self.response = requests.get(
+            self.request_url(path),
+            auth=self.auth,
+            headers=self.request_headers(extra_headers),
+            allow_redirects=False,
+            timeout=self.timeout
+        )
+        self.check_response()
+
+    def check_response(self):
+        if self.response is None:
+            return
+
+        if not self.failed:
+            print(f"Request: {self.response.url} (SUCCESS {self.response.status_code})")
+            return
+
+        print(f"Request: {self.response.url}")
+        print(f"Status: FAILED ({self.response.status_code})")
+        print(f"Headers: {self.response.headers}")
+        print(f"Reason: {self.response.reason}")
+
+    @property
+    def failed(self):
+        return self.response.status_code != self.success
+
+
+def parse_args(argv):
+
+    # default arg values
+    default_systems = Path('/tmp/test_linux_systems.yaml')
+    default_systems_per_request = 200
+    default_api_base_url = 'http://localhost:3000'
+    default_rmt_name = 'rmt.test.example.com'
+    default_rmt_uuid = 'ecf431f8-7faa-48a4-a3f1-6d3abb199086'
+
+    parser = argparse.ArgumentParser(description=
+        'Bulk create systems SCC VirtualizationHosts API testing'
+    )
+
+    # SCC max systems to upload per request
+    parser.add_argument(
+        '--systems_per_request', type=int, action='store', default=default_systems_per_request,
+        help=f'The max number of systems to upload per request to the SCC. (Default: {default_systems_per_request})'
+    )
+
+    # SCC RMT UUID
+    parser.add_argument(
+        '--rmt_uuid', type=str, action='store', default=default_rmt_uuid,
+        help=f'The RMT UUID to report to the SCC. (Default: {default_rmt_uuid})'
+    )
+
+    # SCC RMT Name
+    parser.add_argument(
+        '--rmt_name', type=str, action='store', default=default_rmt_name,
+        help=f'The RMT name to report to the SCC. (Default: {default_rmt_name})'
+    )
+
+    # SCC API base URL
+    parser.add_argument(
+        '-a', '--api_base_url', type=str, action='store', default=default_api_base_url,
+        help=f'The SCC API base URL. (Default: {default_api_base_url})'
+    )
+
+    # SCC mirroring credentials username
+    parser.add_argument(
+        '-u', '--username', type=str, action='store',
+        help='The SCC mirroring credentials username to use for bulk creation. Can be specified via SCC_USERNAME env var.'
+    )
+
+    # SCC mirroring credentials password
+    parser.add_argument(
+        '-p', '--password', type=str, action='store',
+        help='The SCC mirroring credentials password to use for bulk creation. Can be specified via SCC_PASSWORD env var.'
+    )
+
+    # input systems file
+    parser.add_argument(
+        '-s', '--systems', type=Path, action='store', default=default_systems,
+        help=f'The input file containing the details of the Libvirt host and VM systems to bulk create. (Default: {default_systems})'
+    )
+
+    # check creds are valid
+    parser.add_argument(
+        '-c', '--check_creds', action='store_true', default=False,
+        help='Verify that the supplied SCC mirroring credentials are valid.'
+    )
+
+    # parse the supplied arguments
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+
+    if args.username is None:
+        args.username = os.environ.get('SCC_USERNAME')
+
+    if args.password is None:
+        args.password = os.environ.get('SCC_PASSWORD')
+
+    if args.username is None:
+        exit('The SCC username must be specified either via the --username option, or via the SCC_USERNAME env var.')
+
+    if args.password is None:
+        exit('The SCC password must be specified either via the --password option, or via the SCC_PASSWORD env var.')
+
+    scc_config = SccConfig(args.username, args.password, args.api_base_url)
+
+    with args.systems.open('r') as fp:
+        system_details = yaml.safe_load(fp)
+
+    # generate uploadable VM systems entries
+    vm_systems = [
+        dict(login=v['name'], password=v['name'],
+             hostname=v['name'], system_token=v['system_token'],
+             created_at=v['created_at'], last_seen_at=last_seen_time(),
+             hwinfo=dict(hypervisor=v['hypervisor'], uuid=v['uuid']))
+        for v in system_details['vm_systems']
+    ]
+
+    # generate uploadable Libvirt host systems entries
+    libvirt_systems = [
+        dict(login=l['name'], password=l['name'],
+             hostname=l['name'], system_token=l['system_token'],
+             created_at=l['created_at'], last_seen_at=last_seen_time(),
+             hwinfo=dict(
+                 hypervisor=None,
+                 uuid=l['uuid'])
+        )
+        for l in system_details['libvirt_host_systems']
+    ]
+
+    #print(yaml.safe_dump(upload_payload))
+    #print(json.dumps(upload_payload, indent=2))
+
+    # test creds
+    if args.check_creds:
+        check_creds = SccRequest(scc_config)
+        check_creds.get('/connect/organizations/repositories')
+        if check_creds.failed:
+            exit("Invalid SCC Creds")
+
+    # put organizations/systems
+    systems_to_upload = libvirt_systems + vm_systems
+
+    num_systems = len(systems_to_upload)
+    max_per_upload = args.systems_per_request
+
+    for ind in range(0, num_systems, max_per_upload):
+        print(f'Uploading systems {ind} to {min(ind + max_per_upload, num_systems)} of {num_systems} ...')
+        put_systems = SccRequest(scc_config, success=201)
+        put_systems.put_compressed(
+            '/connect/organizations/systems',
+            dict(systems=systems_to_upload[ind:ind + max_per_upload]),
+            extra_headers={
+                'HOST-SYSTEM': args.rmt_name,
+                'RMT': args.rmt_uuid
+            }
+        )
+        if put_systems.failed:
+            exit("Upload of systems details failed")
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/bin/gen_large_datasets
+++ b/bin/gen_large_datasets
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+from pathlib import Path
+import re
+import sys
+import uuid
+import yaml
+
+try:
+    from scc_hypervisor_collector import CollectionResults
+except ImportError as e:
+    exit("The 'scc-hypervisor-collector' package must be installed; did you forget to activate the relevant virtualenv?")
+
+def creation_time():
+    return f"{datetime.datetime.utcnow().isoformat(sep=' ')}000 +0000"
+
+non_alnum_re = re.compile(r'[\W_]+')
+
+def strip_group_name(name):
+    return non_alnum_re.sub('', name)
+
+def vmware_uuid_mangle(uuid):
+    return ''.join([
+        uuid[6:8],
+        uuid[4:6],
+        uuid[2:4],
+        uuid[0:2],
+        "-",
+        uuid[11:13],
+        uuid[9:11],
+        "-",
+        uuid[16:18],
+        uuid[14:16],
+        uuid[18:]
+    ])
+
+
+def gen_vmware_esx_host_vm(group_name, host_id, vm_id, name_sfx):
+    vm_uuid = str(uuid.uuid4())
+    return {
+        'properties': {
+            'vmState': 'x86_64',
+            'vm_name': f'vm_{strip_group_name(str(group_name) + name_sfx)}_{host_id}_{vm_id}',
+            'vmware_uuid': vmware_uuid_mangle(vm_uuid)
+        },
+        'uuid': vm_uuid,
+    }
+
+
+def gen_vmware_esx_host_details(group_name, host_id, num_vms, name_sfx):
+    return {
+        'group_name': str(group_name) + name_sfx,
+        'identifier': repr(f'vim.HostSystem:host-{str(host_id) + name_sfx}'),
+        'properties': {
+            'arch': 'x86_64',
+            'cores': 12,
+            'name': f'esx{host_id}.{strip_group_name(str(group_name) + name_sfx)}.example.com',
+            'ram_mb': 262108,
+            'sockets': 2,
+            'threads': 24,
+            'type': 'vmware',
+        },
+        'systems': [
+            gen_vmware_esx_host_vm(group_name, host_id, vm_id, name_sfx)
+            for vm_id in range(0, num_vms)
+        ],
+    }
+
+
+def gen_vmware_backend(group_name, num_hosts, num_vms, name_sfx):
+    return {
+        'backend': str(group_name) + name_sfx,
+        'details': {
+            'virtualization_hosts': [
+                gen_vmware_esx_host_details(group_name, host_id, num_vms, name_sfx)
+                for host_id in range(0, num_hosts)
+            ]
+        },
+        'valid': True,
+    }
+
+
+def gen_libvirt_vm(group_name, vm_id, name_sfx):
+    return {
+        'properties': {
+            'vmState': 'x86_64',
+            'vm_name': f'vm_{strip_group_name(str(group_name) + name_sfx)}_{vm_id}',
+        },
+        'uuid': str(uuid.uuid4()),
+    }
+
+
+def gen_libvirt_details(group_name, num_vms, name_sfx):
+    return {
+        'group_name': str(group_name) + name_sfx,
+        'identifier': str(uuid.uuid4()),
+        'properties': {
+            'arch': 'x86_64',
+            'cores': 12,
+            'name': f'{strip_group_name(str(group_name) + name_sfx)}.example.com',
+            'ram_mb': 262108,
+            'sockets': 2,
+            'threads': 24,
+            'type': 'QEMU',
+        },
+        'systems': [
+            gen_libvirt_vm(group_name, vm_id, name_sfx)
+            for vm_id in range(0, num_vms)
+        ],
+    }
+
+
+def gen_libvirt_backend(group_name, num_vms, name_sfx):
+    return {
+        'backend': str(group_name) + name_sfx,
+        'details': {
+            'virtualization_hosts': [
+                gen_libvirt_details(group_name, num_vms, name_sfx),
+            ]
+        },
+        'valid': True,
+    }
+
+
+def main(argv):
+    # default arg values
+    default_vmware_backends = 0
+    default_esx_hosts = 2
+    default_esx_vms = 10
+    default_libvirt_backends = 0
+    default_libvirt_vms = 10
+    default_results = Path('/tmp/test_collected_results.yaml')
+    default_systems = Path('/tmp/test_linux_systems.yaml')
+
+    parser = argparse.ArgumentParser(description=
+        'Generate data sets for SCC VirtualizationHosts API testing'
+    )
+
+    # generated results file
+    parser.add_argument(
+        '-o', '--output', type=Path, action='store', default=default_results,
+        help=f'The output file where the generated data set will be written. (Default: {default_results})'
+    )
+
+    # generated systems file
+    parser.add_argument(
+        '-s', '--systems', type=Path, action='store', default=default_systems,
+        help=f'The output file where details of generated Libvirt and VM systems for use with bulk creation will be written. (Default: {default_systems})'
+    )
+
+    # suffix to add to hostnames, if provided
+    parser.add_argument(
+        '-S', '--suffix', type=str, action='store',
+        help='An optional suffix that will be added to the hostnames of generated system names.'
+    )
+
+    # VMWare related options
+    parser.add_argument(
+        '-V', '--vmware', type=int, action='store', default=default_vmware_backends,
+        help=f'The number of VMWare backends to add to the data set. (Default: {default_vmware_backends})'
+    )
+    parser.add_argument(
+        '-E', '--esx-hosts', type=int, action='store', default=default_esx_hosts,
+        help=f'The number of ESX hosts per VMWare backend. (Default: {default_esx_hosts})'
+    )
+    parser.add_argument(
+        '-e', '--esx-vms', type=int, action='store', default=default_esx_vms,
+        help=f'The number of VMs per ESX host in each VMWare backend. (Default: {default_esx_vms})'
+    )
+
+    # Libvirt related options
+    parser.add_argument(
+        '-L', '--libvirt', type=int, action='store', default=default_libvirt_backends,
+        help=f'The number of Libvirt backends to add to the data set. (Default: {default_libvirt_backends})'
+    )
+    parser.add_argument(
+        '-l', '--libvirt-vms', type=int, action='store', default=default_libvirt_vms,
+        help=f'The number of Libvirt backends to add to the data set. (Default: {default_libvirt_vms})'
+    )
+
+    # parse the supplied arguments
+    args = parser.parse_args(argv)
+
+    if args.suffix:
+        name_sfx = '_' + args.suffix
+    else:
+        name_sfx = ''
+
+    # Generate VMWare backends
+    vmware_backends = [
+        gen_vmware_backend(f'vcenter{vmware_id}', args.esx_hosts, args.esx_vms, name_sfx)
+        for vmware_id in range(0, args.vmware)
+    ]
+
+    # Generate VMWare backends
+    libvirt_backends = [
+        gen_libvirt_backend(f'libvirt{libvirt_id}', args.libvirt_vms, name_sfx)
+        for libvirt_id in range(0, args.libvirt)
+    ]
+
+    collected = CollectionResults()
+    collected._results = vmware_backends + libvirt_backends
+
+    # extract vm uuids from results
+    vm_systems = [
+        dict(name=s['properties']['vm_name'],
+             uuid=s['uuid'],
+             created_at=creation_time(),
+             system_token=str(uuid.uuid4()),
+             hypervisor=v['properties']['type'])
+        for b in collected.results
+        for v in b['details']['virtualization_hosts']
+        for s in v['systems']
+        if b['valid']
+    ]
+
+    # extract libvirt host uuids from results
+    libvirt_host_systems = [
+        dict(name=v['properties']['name'],
+             uuid=v['identifier'],
+             created_at=creation_time(),
+             system_token=str(uuid.uuid4()))
+        
+        for b in collected.results
+        for v in b['details']['virtualization_hosts']
+        if b['valid'] and v['properties']['type'] == 'QEMU'
+    ]
+
+    collected.save(args.output)
+    print(f'Generated collection results saved to: {args.output}')
+
+    with args.systems.open('w') as fp:
+        yaml.safe_dump(dict(vm_systems=vm_systems,
+                            libvirt_host_systems=libvirt_host_systems),
+                       fp)
+    print(f'systems from collection results saved to: {args.systems}')
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/doc/Adhoc_Testing.md
+++ b/doc/Adhoc_Testing.md
@@ -1,0 +1,131 @@
+# Adhoc Testing
+
+The `bin/gen_large_datasets` utility can be utilies to generate synthesised:
+
+  * "collected" results for simulated VMWare and/or Libvirt hypervisor
+    topologiies.
+
+  * systems details including hostnames, system UUIDs, tokens and
+    created\_at time stamps for the relevant nodes in the simulated
+    hypervisor topologiies.
+
+The `bin/bulk_create` utility can be used to create the ficticious systems
+in the simulated hypervisor topologies.
+
+The synthesised results can be passed as then collection details source to
+the `scc-hypervior-collector` command, via then --input option, alllowing
+validation that uploading hypervisor topology details to the SCC works
+correctly using the new `/connect/organization/virtualization_hosts` PUT
+request.
+
+
+## `gen_large_datasets`
+
+NOTE: This command should be run in an environment where the `scc_hypervisor_collector.api` can be imported.
+
+```
+usage: gen_large_datasets [-h] [-o OUTPUT] [-s SYSTEMS] [-S SUFFIX] [-V VMWARE] [-E ESX_HOSTS] [-e ESX_VMS] [-L LIBVIRT]
+                          [-l LIBVIRT_VMS]
+
+Generate data sets for SCC VirtualizationHosts API testing
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -o OUTPUT, --output OUTPUT
+                        The output file where the generated data set will be written. (Default: /tmp/test_collected_results.yaml)
+  -s SYSTEMS, --systems SYSTEMS
+                        The output file where details of generated Libvirt and VM systems for use with bulk creation will be written.
+                        (Default: /tmp/test_linux_systems.yaml)
+  -S SUFFIX, --suffix SUFFIX
+                        An optional suffix that will be added to the hostnames of generated system names.
+  -V VMWARE, --vmware VMWARE
+                        The number of VMWare backends to add to the data set. (Default: 0)
+  -E ESX_HOSTS, --esx-hosts ESX_HOSTS
+                        The number of ESX hosts per VMWare backend. (Default: 2)
+  -e ESX_VMS, --esx-vms ESX_VMS
+                        The number of VMs per ESX host in each VMWare backend. (Default: 10)
+  -L LIBVIRT, --libvirt LIBVIRT
+                        The number of Libvirt backends to add to the data set. (Default: 0)
+  -l LIBVIRT_VMS, --libvirt-vms LIBVIRT_VMS
+                        The number of Libvirt backends to add to the data set. (Default: 10)
+```
+
+
+The `gen_large_datasets` tool takes as arguments simulation parameters
+specifying:
+
+  * the number of VMWare vCenters, associated ESX hosts, and number of SLE
+    VMs per ESX host.
+
+  * the number of SLE Libvirt hosts, and number of SLE VMs per Libvirt host.
+
+  * an optional suffix that will be included in all names where appropriate.
+
+The default generated files, which can be overridden via the appropriate
+options, are:
+
+  * `/tmp/test_collected_results.yaml` for simulated collected results.
+
+  * `/tmp/test_linux_systems.yaml` for simulated systems details.
+
+For example to generate a simulated collected results, and associated systems
+details for a mixture of 2 vCenters, each with 10 ESX hosts running 50 SLE VMs,
+and 20 Libvirt hosts each running 50 SLE VMs, you could use a command like the
+following:
+
+```
+$ .tox/dev/bin/python3 bin/gen_large_datasets -V 2 -E 5 -e 100 -L 20 -l 50 -S mixed2k
+```
+
+
+## `bulk_create`
+
+```
+usage: bulk_create [-h] [--systems_per_request SYSTEMS_PER_REQUEST] [--rmt_uuid RMT_UUID] [--rmt_name RMT_NAME] [-a API_BASE_URL]
+                   [-u USERNAME] [-p PASSWORD] [-s SYSTEMS] [-c]
+
+Bulk create systems SCC VirtualizationHosts API testing
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --systems_per_request SYSTEMS_PER_REQUEST
+                        The max number of systems to upload per request to the SCC. (Default: 200)
+  --rmt_uuid RMT_UUID   The RMT UUID to report to the SCC. (Default: ecf431f8-7faa-48a4-a3f1-6d3abb199086)
+  --rmt_name RMT_NAME   The RMT name to report to the SCC. (Default: rmt.test.example.com)
+  -a API_BASE_URL, --api_base_url API_BASE_URL
+                        The SCC API base URL. (Default: http://localhost:3000)
+  -u USERNAME, --username USERNAME
+                        The SCC mirroring credentials username to use for bulk creation. Can be specified via SCC_USERNAME env var.
+  -p PASSWORD, --password PASSWORD
+                        The SCC mirroring credentials password to use for bulk creation. Can be specified via SCC_PASSWORD env var.
+  -s SYSTEMS, --systems SYSTEMS
+                        The input file containing the details of the Libvirt host and VM systems to bulk create. (Default:
+                        /tmp/test_linux_systems.yaml)
+  -c, --check_creds     Verify that the supplied SCC mirroring credentials are valid.
+```
+
+The `bulk_create` tool takes as arguments:
+
+  * the SCC credentials to use to upload the simulated systems, which can be
+    alternatively specified via the SCC_USERNAME and SCC_PASSWORD environment
+    variables.
+
+  * the SCC API URL to use.
+
+  * the simulated systems details file generated by the `gen_large_datasets`
+    tool.
+
+  * optional simulated RMT identification details.
+
+  * optional number of systems to upload per request
+
+The specified SCC credentials can be validated using the `--check_creds`
+option as well.
+
+For example to create the simulated systems associated with the above
+generated `mixed2k` dataset in a SCC development environment running on
+localhost:5000, you could use a command like the following:
+
+```
+$ bin/bulk_create -s /tmp/test_linux_systems.yaml -a http://localhost:5000 -u ${SCC_ACCOUNT} -p ${SCC_PASSWORD}
+```

--- a/doc/Adhoc_Testing.md
+++ b/doc/Adhoc_Testing.md
@@ -1,6 +1,6 @@
 # Adhoc Testing
 
-The `bin/gen_large_datasets` utility can be utilies to generate synthesised:
+The `bin/gen_large_datasets` utility can be utilised to generate synthesised:
 
   * "collected" results for simulated VMWare and/or Libvirt hypervisor
     topologiies.
@@ -9,7 +9,7 @@ The `bin/gen_large_datasets` utility can be utilies to generate synthesised:
     created\_at time stamps for the relevant nodes in the simulated
     hypervisor topologiies.
 
-The `bin/bulk_create` utility can be used to create the ficticious systems
+The `bin/bulk_create` utility can be used to create the fictitious systems
 in the simulated hypervisor topologies.
 
 The synthesised results can be passed as then collection details source to

--- a/doc/Adhoc_Testing.md
+++ b/doc/Adhoc_Testing.md
@@ -129,3 +129,27 @@ localhost:5000, you could use a command like the following:
 ```
 $ bin/bulk_create -s /tmp/test_linux_systems.yaml -a http://localhost:5000 -u ${SCC_ACCOUNT} -p ${SCC_PASSWORD}
 ```
+
+## Testing SCC VirtualizationHosts API
+
+You can use the `bin/gen_large_datasets` tool (above) to create the synthesised collected results and associated systems details.
+
+Once you have registered the systems using `bin/bulk_create` tool (above) you can now run the `scc-hypervisor-collector` command to upload the synthesised collected results, using the configured SCC credentials, as follows:
+
+```
+$ bin/scc-hypervisor-collector --upload --input /tmp/test_collected_results.yaml
+```
+
+## Cleaning up the fake systems created with `bulk_create`
+
+Once testing has finished you can easily delete all of the fake systems that were registered via the SCC Web UI as follows:
+
+* Log in to the SCC account associated with the Organization that the systems were registered to.
+
+* Select the appropriate organization from the "My Organizations" list
+
+* Select the "Proxies" tab
+
+* Locate the "fake" RMT with the specified UUID (default per the help message for the `bulk_create` tool) and click on the "Show details" link
+
+* Click on the "Delete this registration proxy" button to delete the fake RMT and all associated systems registered via it.


### PR DESCRIPTION
Add gen_large_datasets and bulk_create utilities
  
gen_large_datasets can be used to generate large fictitious data sets
that can be leveraged by the scc-hypervisor-collector --input option
to test the backend SCC API, pre-registering the associated VMs and
Libvirt hosts using bulk_create if desired.

The tool generates two output files:
* The details output file can be used as an input file to the
  scc-hypervisor-collector.
* The systems output file provides lists of the libvirt host UUIDs
  and the Libvirt and VMWare manage VM UUIDs from the generated
  results file, along with system_token UUIDs, so that they can be
  "registered" within a test environment as SLE systems, if desired,
  using bulk_create.
