### PR TITLE
Add support for Python 3.11, fix Python 3.6 testing

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Install package dependencies

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: System :: Systems Administration',
     ],
     package_dir={

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 envlist =
     cli,
     check,
-    {py36,py37,py38,py39,py310}-cover,
+    {py36,py37,py38,py39,py310,py311}-cover,
 
 [gh-actions]
 python =
@@ -14,6 +14,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 wheel = true
@@ -23,6 +24,7 @@ basepython =
     py38: {env:TOXPYTHON:python3.8}
     py39: {env:TOXPYTHON:python3.9}
     py310: {env:TOXPYTHON:python3.10}
+    py311: {env:TOXPYTHON:python3.11}
     {check,cli,dev}: {env:TOXPYTHON:python3}
 description = Basic command test
 setenv =


### PR DESCRIPTION
Add support for Python 3.11 testing as it has been officially released since the tox & CI configurations were last revised.

Update scc-hypervisor-collector package attributes to indicate that Python 3.11 is supported.

Fix Python 3.6 testing by downgrading to use Ubuntu 20.04 image, rather ubuntu-latest.

Implements: #98
Fixes: #96